### PR TITLE
Change character set for base36

### DIFF
--- a/source/Support/Radix.cpp
+++ b/source/Support/Radix.cpp
@@ -117,8 +117,7 @@ private:
 
 static constexpr char baseFNDigits[] =
     "0123456789"
-    "abcdefghijklmnopqrstuvwxyz"
-    "()_-,";
+    "abcdefghijklmnopqrstuvwxyz";
 
 static constexpr std::size_t baseFN = sizeof(baseFNDigits) - 1;
 


### PR DESCRIPTION
Character set for base36 encoding cased `baseFN` to equal 41 instead of 36. Remove excess characters so modulo is correct.