### PR TITLE
Handlebars engine uses string_view::data

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         id: cpp-matrix
         with:
           compilers: |
-            gcc 13.2
+            gcc 13.1
             clang 16
             msvc 14.34
           standards: '>=20'

--- a/src/lib/Support/Handlebars.cpp
+++ b/src/lib/Support/Handlebars.cpp
@@ -1020,7 +1020,7 @@ findTag(std::string_view &tag, std::string_view templateText)
     if (escaped)
     {
         bool const doubleEscaped = pos != 1 && templateText[pos - 2] == '\\';
-        tag = {tag.begin() - 1 - doubleEscaped, tag.end()};
+        tag = {tag.data() - 1 - doubleEscaped, tag.data() + tag.size()};
     }
     return true;
 }


### PR DESCRIPTION
The handlebars engine needs to use string_view::data() instead of string_view::begin() on MSVC.