### PR TITLE
Replicate Boost.URL sections

### DIFF
--- a/share/mrdocs/addons/generator/asciidoc/partials/enum.adoc.hbs
+++ b/share/mrdocs/addons/generator/asciidoc/partials/enum.adoc.hbs
@@ -5,12 +5,12 @@
 
 == Synopsis
 
+{{>source dcl=(primary_location symbol)}}
+
 [source,cpp,subs="verbatim,macros,-callouts"]
 ----
 enum {{symbol.name}};
 ----
-
-{{>source dcl=(primary_location symbol)}}
 
 {{#if symbol.members}}
 == Members

--- a/share/mrdocs/addons/generator/asciidoc/partials/enumerator.adoc.hbs
+++ b/share/mrdocs/addons/generator/asciidoc/partials/enumerator.adoc.hbs
@@ -5,12 +5,12 @@
 
 == Synopsis
 
+{{>source dcl=(primary_location symbol)}}
+
 [source,cpp,subs="verbatim,macros,-callouts"]
 ----
 {{symbol.name}}{{#if symbol.initializer}} = {{symbol.initializer}}{{~/if}}
 ----
-
-{{>source dcl=(primary_location symbol)}}
 
 {{#if symbol.doc.description}}
 == Description

--- a/share/mrdocs/addons/generator/asciidoc/partials/field.adoc.hbs
+++ b/share/mrdocs/addons/generator/asciidoc/partials/field.adoc.hbs
@@ -5,6 +5,8 @@
 
 == Synopsis
 
+{{>source dcl=(primary_location symbol)}}
+
 [source,cpp,subs="verbatim,macros,-callouts"]
 ----
 {{#if symbol.isMutable}}mutable
@@ -14,8 +16,6 @@
 {{>declarator-after symbol.type~}}
 ;
 ----
-
-{{>source dcl=(primary_location symbol)}}
 
 {{#if symbol.doc.description}}
 == Description

--- a/share/mrdocs/addons/generator/asciidoc/partials/friend.adoc.hbs
+++ b/share/mrdocs/addons/generator/asciidoc/partials/friend.adoc.hbs
@@ -5,6 +5,8 @@
 
 == Synopsis
 
+{{>source dcl=(primary_location symbol)}}
+
 {{#if symbol.type~}}
 [source,cpp,subs="verbatim,macros,-callouts"]
 ----
@@ -15,8 +17,6 @@ friend {{>declarator symbol.type}};
 {{else if (and symbol.symbol (eq symbol.symbol.kind "function"))~}}
 {{>function-decl symbol.symbol isFriend=true~}}
 {{/if}}
-
-{{>source dcl=(primary_location symbol)}}
 
 {{#if symbol.doc.description}}
 == Description

--- a/share/mrdocs/addons/generator/asciidoc/partials/function.adoc.hbs
+++ b/share/mrdocs/addons/generator/asciidoc/partials/function.adoc.hbs
@@ -14,4 +14,31 @@
 
 {{symbol.doc.description}}
 
+{{! TODO: == Exceptions }}
+
+{{#if symbol.return}}
+== Return Value
+
+* `{{symbol.return.name}}` {{! TODO: symbol.doc.return }}
+
+{{/if}}
+
+{{#if symbol.params}}
+== Parameters
+
+|===
+| Name | Type {{! TODO: | Description }}
+
+{{#each symbol.params}}
+| *{{name}}*
+| `{{type.name}}`
+{{! TODO: symbol.doc.params.[name] }}
+
+{{/each}}
+|===
+
+{{/if}}
+
+{{! TODO: == See Also }}
+
 {{/if}}

--- a/share/mrdocs/addons/generator/asciidoc/partials/function.adoc.hbs
+++ b/share/mrdocs/addons/generator/asciidoc/partials/function.adoc.hbs
@@ -5,9 +5,9 @@
 
 == Synopsis
 
-{{>function-decl symbol isFriend=false}}
-
 {{>source dcl=(primary_location symbol)}}
+
+{{>function-decl symbol isFriend=false}}
 
 {{#if symbol.doc.description}}
 == Description

--- a/share/mrdocs/addons/generator/asciidoc/partials/namespace.adoc.hbs
+++ b/share/mrdocs/addons/generator/asciidoc/partials/namespace.adoc.hbs
@@ -2,12 +2,12 @@
 = {{#if symbol.name}}Namespace {{symbol.name}}{{else if symbol.parent}}Unnamed namespace{{else}}Global namespace{{/if}}
 
 {{#each (group_by symbol.members "kind")}}
-== {{#if (eq @key "record")}}Classes{{else}}{{capitalize @key}}s{{/if}}
+== {{#if (eq @key "record")}}Types{{else if (eq @key "variable")}}Constants{{else}}{{capitalize @key}}s{{/if}}
 
 [,cols=2]
 |===
 |Name |Description
-{{#each .}}
+{{#each (sort_by . "name")}}
 |xref:{{ref}}[`pass:v[{{name}}]`] |{{doc.brief}}
 {{/each}}
 |===

--- a/share/mrdocs/addons/generator/asciidoc/partials/record.adoc.hbs
+++ b/share/mrdocs/addons/generator/asciidoc/partials/record.adoc.hbs
@@ -5,9 +5,9 @@
 
 == Synopsis
 
-{{>record-decl symbol isFriend=false}}
-
 {{>source dcl=(primary_location symbol)}}
+
+{{>record-decl symbol isFriend=false}}
 
 {{#with symbol.interface}}
 {{> tranche tranche=public label=""}}

--- a/share/mrdocs/addons/generator/asciidoc/partials/record.adoc.hbs
+++ b/share/mrdocs/addons/generator/asciidoc/partials/record.adoc.hbs
@@ -21,3 +21,5 @@
 {{symbol.doc.description}}
 
 {{/if}}
+
+{{! TODO: == See Also }}

--- a/share/mrdocs/addons/generator/asciidoc/partials/record.adoc.hbs
+++ b/share/mrdocs/addons/generator/asciidoc/partials/record.adoc.hbs
@@ -11,8 +11,8 @@
 
 {{#with symbol.interface}}
 {{> tranche tranche=public label=""}}
-{{> tranche tranche=protected label=" Protected"}}
-{{> tranche tranche=private label=" Private"}}
+{{> tranche tranche=protected label="Protected"}}
+{{> tranche tranche=private label="Private"}}
 {{/with}}
 
 {{#if symbol.doc.description}}

--- a/share/mrdocs/addons/generator/asciidoc/partials/source.adoc.hbs
+++ b/share/mrdocs/addons/generator/asciidoc/partials/source.adoc.hbs
@@ -1,1 +1,2 @@
-Declared in file <{{dcl.file}}> on line {{dcl.line}}
+// <{{dcl.file}}>: line {{dcl.line}}
+Declared in header <{{dcl.file}}>

--- a/share/mrdocs/addons/generator/asciidoc/partials/tranche.adoc.hbs
+++ b/share/mrdocs/addons/generator/asciidoc/partials/tranche.adoc.hbs
@@ -1,36 +1,36 @@
 {{#if tranche.records}}
-=={{label}} Types
+== {{label}} Types
 {{>info-list tranche.records}}
 {{/if}}
 {{#if tranche.types}}
 {{#if label}}
-=={{label}} Types
+== {{label}} Types
 {{else}}
-== Types
+==  Types
 {{/if}}
 {{>info-list tranche.types}}
 {{/if}}
 {{#if tranche.functions}}
-=={{label}} Member Functions
+== {{label}} Member Functions
 {{>info-list tranche.functions}}
 {{/if}}
 {{#if tranche.enums}}
-=={{label}} Enums
+== {{label}} Enums
 {{>info-list tranche.enums}}
 {{/if}}
 {{#if tranche.fields}}
-=={{label}} Data Members
+== {{label}} Data Members
 {{>info-list tranche.fields}}
 {{/if}}
 {{#if tranche.staticfunctions}}
-=={{label}} Static Member Functions
+== {{label}} Static Member Functions
 {{>info-list tranche.staticfunctions}}
 {{/if}}
 {{#if tranche.staticdata}}
-=={{label}} Static Data Members
+== {{label}} Static Data Members
 {{>info-list tranche.staticdata}}
 {{/if}}
 {{#if tranche.friends}}
-=={{label}} Friends
+== {{label}} Friends
 {{>info-list tranche.friends}}
 {{/if}}

--- a/share/mrdocs/addons/generator/asciidoc/partials/typedef.adoc.hbs
+++ b/share/mrdocs/addons/generator/asciidoc/partials/typedef.adoc.hbs
@@ -5,6 +5,8 @@
 
 == Synopsis
 
+{{>source dcl=(primary_location symbol)}}
+
 [source,cpp,subs="verbatim,macros,-callouts"]
 ----
 {{#if symbol.isUsing~}}
@@ -16,8 +18,6 @@
 {{~/if}}
 ;
 ----
-
-{{>source dcl=(primary_location symbol)}}
 
 {{#if symbol.doc.description}}
 == Description

--- a/share/mrdocs/addons/generator/asciidoc/partials/variable.adoc.hbs
+++ b/share/mrdocs/addons/generator/asciidoc/partials/variable.adoc.hbs
@@ -5,6 +5,8 @@
 
 == Synopsis
 
+{{>source dcl=(primary_location symbol)}}
+
 [source,cpp,subs="verbatim,macros,-callouts"]
 ----
 {{#if symbol.template}}{{>template-head symbol.template}}
@@ -24,8 +26,6 @@
 {{>declarator-after symbol.type~}}
 ;
 ----
-
-{{>source dcl=(primary_location symbol)}}
 
 {{#if symbol.doc.description}}
 == Description


### PR DESCRIPTION
This PR replicates sections and components from the Boost.URL docca documentation that we can already represent with mrdocs templates.