### PR TITLE
build: use duktape package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,19 +112,6 @@ jobs:
           echo "llvm_root=$llvm_root"
           echo -E "llvm-root=$llvm_root" >> $GITHUB_OUTPUT
 
-      - name: Install Duktape
-        id: duktape-install
-        shell: bash
-        run: |
-          set -xe
-          curl -L -o "duktape-2.7.0.tar.xz" "https://github.com/svaarala/duktape/releases/download/v2.7.0/duktape-2.7.0.tar.xz"
-          duktape_dir="${{runner.tool_cache}}/duktape"
-          duktape_dir=$(echo "$duktape_dir" | sed 's/\\/\//g')
-          mkdir -p "$duktape_dir"
-          tar -xvf "duktape-2.7.0.tar.xz" -C "$duktape_dir"
-          echo "duktape-dir=$duktape_dir/duktape-2.7.0" >> $GITHUB_OUTPUT
-          echo "duktape_dir=$duktape_dir/duktape-2.7.0"
-
       - name: Install Node.js
         uses: actions/setup-node@v3
         with:
@@ -143,7 +130,7 @@ jobs:
         id: package-install
         with:
           apt-get: ${{ matrix.install }} openjdk-11-jdk ninja-build ${{ matrix.compiler == 'clang' && 'libstdc++-12-dev' || '' }}
-          vcpkg: fmt libxml2[tools]
+          vcpkg: fmt duktape libxml2[tools]
           cc: ${{ steps.setup-cpp.outputs.cc || matrix.cc }}
           ccflags: ${{ matrix.ccflags }}
           cxx: ${{ steps.setup-cpp.outputs.cxx || matrix.cxx }}
@@ -162,7 +149,7 @@ jobs:
           cxx: ${{ steps.setup-cpp.outputs.cxx || matrix.cxx }}
           cxxflags: ${{ matrix.cxxflags }}${{ ( matrix.compiler == 'gcc' && ' -static-libstdc++') || '' }}${{ ( matrix.asan && ' -static-libasan') || '' }}${{ ( matrix.tsan && ' -static-libtsan') || '' }}
           install-prefix: .local
-          extra-args: ${{ format('-D LLVM_ROOT="{0}" -D Clang_ROOT="{0}" -D DUKTAPE_SOURCE_ROOT="{1}" -D CMAKE_EXPORT_COMPILE_COMMANDS=ON', steps.llvm-install.outputs.llvm-root || '/usr/local', steps.duktape-install.outputs.duktape-dir) }}
+          extra-args: ${{ format('-D LLVM_ROOT="{0}" -D Clang_ROOT="{0}" -D CMAKE_EXPORT_COMPILE_COMMANDS=ON', steps.llvm-install.outputs.llvm-root || '/usr/local') }}
           export-compile-commands: ${{ matrix.time-trace }}
           package: ${{ matrix.is-main }}
           package-dir: packages

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,35 +100,11 @@ string(REGEX REPLACE " /W[0-4]" "" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
 string(REGEX REPLACE " /W[0-4]" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
 
 # Duktape
-set(DUKTAPE_SOURCE_ROOT "" CACHE STRING "Root of the Duktape source tree")
-if (NOT DUKTAPE_SOURCE_ROOT)
-    message(FATAL_ERROR
-            "Duktape source root not found.\n"
-            "Please set DUKTAPE_SOURCE_ROOT to the root of the Duktape source tree.\n"
-            "https://github.com/svaarala/duktape/releases/download/v2.7.0/duktape-2.7.0.tar.xz\n")
+set(DUKTAPE_PACKAGE_NAME duktape)
+if (WIN32)
+    set(DUKTAPE_PACKAGE_NAME Duktape)
 endif()
-if (NOT EXISTS "${DUKTAPE_SOURCE_ROOT}")
-    message(FATAL_ERROR
-            "DUKTAPE_SOURCE_ROOT (${DUKTAPE_SOURCE_ROOT}) does not exist.\n")
-endif()
-if (NOT EXISTS "${DUKTAPE_SOURCE_ROOT}/src/duktape.c")
-    message(FATAL_ERROR
-            "DUKTAPE_SOURCE_ROOT (${DUKTAPE_SOURCE_ROOT}) is invalid.\n"
-            "No /src/duktape.c found.\n"
-            "Please set DUKTAPE_SOURCE_ROOT to the root of the Duktape source tree.\n")
-endif()
-get_filename_component(DUKTAPE_SOURCE_ROOT "${DUKTAPE_SOURCE_ROOT}" ABSOLUTE)
-add_library(duktape ${DUKTAPE_SOURCE_ROOT}/src/duktape.c ${DUKTAPE_SOURCE_ROOT}/src/duktape.h)
-target_include_directories(
-    duktape PUBLIC
-        "$<BUILD_INTERFACE:${DUKTAPE_SOURCE_ROOT}/src>"
-        "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
-add_library(duktape::duktape ALIAS duktape)
-if (CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
-    target_compile_options(duktape PRIVATE -w)
-elseif (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-    target_compile_options(duktape PRIVATE /w)
-endif()
+find_package(${DUKTAPE_PACKAGE_NAME} REQUIRED)
 
 # fmt
 find_package(fmt REQUIRED CONFIG)
@@ -167,7 +143,9 @@ target_compile_definitions(
 # Deps
 target_include_directories(mrdocs-core SYSTEM PUBLIC ${LLVM_INCLUDE_DIRS})
 target_include_directories(mrdocs-core SYSTEM PUBLIC ${CLANG_INCLUDE_DIRS})
-target_link_libraries(mrdocs-core PUBLIC fmt::fmt duktape::duktape)
+target_link_libraries(mrdocs-core PUBLIC fmt::fmt)
+target_include_directories(mrdocs-core SYSTEM PRIVATE ${DUKTAPE_INCLUDE_DIRS})
+target_link_libraries(mrdocs-core PRIVATE ${DUKTAPE_LIBRARY})
 
 # Clang
 if (CLANG_SIMPLE_LIBS)
@@ -408,7 +386,7 @@ if (MRDOCS_INSTALL)
     #-------------------------------------------------
     # lib
     #-------------------------------------------------
-    install(TARGETS mrdocs-core duktape
+    install(TARGETS mrdocs-core
             EXPORT mrdocs-targets
             LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
             ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
@@ -428,12 +406,6 @@ if (MRDOCS_INSTALL)
             COMPONENT development
             FILES_MATCHING
             PATTERN "*.[hi]pp")
-
-    install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/third-party/duktape/src/
-            DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-            COMPONENT development
-            FILES_MATCHING
-            PATTERN "*.h")
 
     #-------------------------------------------------
     # share

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -17,7 +17,6 @@
         "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
         "LLVM_ROOT": "$env{LLVM_ROOT}",
         "Clang_ROOT": "$env{LLVM_ROOT}",
-        "DUKTAPE_SOURCE_ROOT": "$env{DUKTAPE_SOURCE_ROOT}",
         "MRDOCS_BUILD_TESTS": "ON"
       },
       "vendor": {

--- a/CMakeUserPresets.json.example
+++ b/CMakeUserPresets.json.example
@@ -15,7 +15,6 @@
       "cacheVariables": {
         "LLVM_ROOT": "C:\\Users\\$env{USERNAME}\\Libraries\\llvm-project\\llvm\\install\\MSVC\\Debug",
         "Clang_ROOT": "C:\\Users\\$env{USERNAME}\\Libraries\\llvm-project\\llvm\\install\\MSVC\\Debug",
-        "DUKTAPE_SOURCE_ROOT": "C:\\Users\\$env{USERNAME}\\Libraries\\duktape-2.7.0",
         "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
       },
       "condition": {
@@ -71,7 +70,6 @@
         "CMAKE_C_COMPILER": "/usr/bin/gcc-13",
         "LLVM_ROOT": "/home/$env{USER}/libraries/llvm-project/llvm/install/Linux/Release",
         "Clang_ROOT": "/home/$env{USER}/libraries/llvm-project/llvm/install/Linux/Release",
-        "DUKTAPE_SOURCE_ROOT": "/home/$env{USER}/libraries/duktape-2.7.0",
         "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
       },
       "vendor": {

--- a/docs/modules/ROOT/pages/install.adoc
+++ b/docs/modules/ROOT/pages/install.adoc
@@ -214,30 +214,12 @@ Return from `./third-party/llvm-project/build` to the parent `third-party` direc
 cd ../..
 ----
 
-[#duktape]
-=== Downloading Duktape
-
-MrDocs contains functionality to allow users to define their own templates for the documentation.
-Duktape is a JavaScript engine that is used by MrDocs to parse and evaluate template helpers.
-
-The release files can be obtained from the Duktape repository:
-
-[source,bash]
-----
-curl -L -o "duktape-2.7.0.tar.xz" "https://github.com/svaarala/duktape/releases/download/v2.7.0/duktape-2.7.0.tar.xz"
-tar -xvf "duktape-2.7.0.tar.xz"
-----
-
-Duktape provides no CMake integration scripts.
-For this reason, MrDocs needs direct access to the source files for Duktape.
-This means that's all you need to do for `duktape`.
-
 === CMake dependencies
 
 All other dependencies provide CMake integration scripts and can be obtained from https://www.vcpkg.io/[vcpkg] or installed manually.
 
 * `fmt` >= 10
-* `zlib`
+* `duktape`
 
 For development builds, which include tests, you will also need:
 

--- a/mrdocs-config.cmake.in
+++ b/mrdocs-config.cmake.in
@@ -21,6 +21,7 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_INSTALL_DATAROOTDIR}/mrdocs/cmake")
 # Find dependencies
 find_dependency(LLVM)
 find_dependency(Clang)
+find_dependency(@DUKTAPE_PACKAGE_NAME@)
 find_dependency(fmt)
 
 # Create imported targets

--- a/vcpkg.json.example
+++ b/vcpkg.json.example
@@ -6,12 +6,20 @@
       "name": "fmt",
       "version>=": "10.0.0"
     },
-    {
-      "name": "libxml2",
-      "features": [
-        "tools"
+    "duktape"
+  ],
+  "features": {
+    "tests": {
+      "description": "Build tests",
+      "dependencies": [
+        {
+          "name": "libxml2",
+          "features": [
+            "tools"
+          ]
+        }
       ]
     }
-  ],
+  },
   "builtin-baseline": "3715d743ac08146d9b7714085c1babdba9f262d5"
 }


### PR DESCRIPTION
This commit changes the Duktape setup to use the CMake find_package command to locate and configure the Duktape library. Direct access to source files through DUKTAPE_SOURCE_ROOT has been removed in order to respond to Duktape providing its own CMake integration scripts via vcpkg.

Additionally, installation instructions for Duktape and references to DUKTAPE_SOURCE_ROOT have been removed from relevant files and examples. Instead, the Duktape dependency is now managed by vcpkg in CI. This simplifies the setup of the development environment.