### PR TITLE
feat: complete JavaScript helpers support

### DIFF
--- a/CMakeUserPresets.json.example
+++ b/CMakeUserPresets.json.example
@@ -61,6 +61,15 @@
       }
     },
     {
+      "name": "DebWithOpt-ClangCL",
+      "inherits": "DebWithOpt-MSVC",
+      "binaryDir": "${sourceDir}/build/${presetName}",
+      "cacheVariables": {
+        "CMAKE_C_COMPILER": "clang-cl.exe",
+        "CMAKE_CXX_COMPILER": "clang-cl.exe"
+      }
+    },
+    {
       "name": "Debug-GCC",
       "inherits": "debug",
       "binaryDir": "${sourceDir}/build/debug-gcc",

--- a/include/mrdocs/Support/JavaScript.hpp
+++ b/include/mrdocs/Support/JavaScript.hpp
@@ -20,6 +20,9 @@
 
 namespace clang {
 namespace mrdocs {
+
+class Handlebars;
+
 namespace js {
 
 struct Access;
@@ -213,6 +216,42 @@ public:
      */
     MRDOCS_DECL
     ~Scope();
+
+    /** Push an integer to the stack
+     */
+    MRDOCS_DECL
+    Value
+    pushInteger(std::int64_t value);
+
+    /** Push a double to the stack
+     */
+    MRDOCS_DECL
+    Value
+    pushDouble(double value);
+
+    /** Push a boolean to the stack
+     */
+    MRDOCS_DECL
+    Value
+    pushBoolean(bool value);
+
+    /** Push a string to the stack
+     */
+    MRDOCS_DECL
+    Value
+    pushString(std::string_view value);
+
+    /** Push a new object to the stack
+     */
+    MRDOCS_DECL
+    Value
+    pushObject();
+
+    /** Push a new array to the stack
+     */
+    MRDOCS_DECL
+    Value
+    pushArray();
 
     /** Compile and run a script.
 
@@ -972,6 +1011,20 @@ isFunction() const noexcept
 {
     return type() == Type::function;
 }
+
+/** Register a JavaScript helper function
+
+    This function registers a JavaScript function
+    as a helper function that can be called from
+    Handlebars templates.
+ */
+MRDOCS_DECL
+Expected<void, Error>
+registerHelper(
+    clang::mrdocs::Handlebars& hbs,
+    std::string_view name,
+    Context& ctx,
+    std::string_view script);
 
 } // js
 } // mrdocs

--- a/share/mrdocs/addons/generator/html/helpers/add.js
+++ b/share/mrdocs/addons/generator/html/helpers/add.js
@@ -1,0 +1,3 @@
+function add(a, b) {
+    return a + b;
+}

--- a/src/lib/Gen/adoc/Builder.cpp
+++ b/src/lib/Gen/adoc/Builder.cpp
@@ -57,75 +57,28 @@ Builder(
             return Error::success();
     }).maybeThrow();
 
-    // load helpers
-    js::Scope scope(ctx_);
+    // Load JavaScript helpers
     std::string helpersPath = files::appendPath(
         config->addonsDir, "generator", "asciidoc", "helpers");
     forEachFile(helpersPath, true,
-        [&](std::string_view pathName)
+        [&](std::string_view pathName)-> Expected<void>
         {
             // Register JS helper function in the global object
             constexpr std::string_view ext = ".js";
-            if (!pathName.ends_with(ext))
-            {
-                return Error::success();
-            }
+            if (!pathName.ends_with(ext)) return {};
             auto name = files::getFileName(pathName);
             name.remove_suffix(ext.size());
-            auto text = files::getFileText(pathName);
-            if (!text)
-            {
-                return text.error();
-            }
-            auto JSFn = scope.compile_function(*text);
-            if (!JSFn)
-            {
-                return JSFn.error();
-            }
-            scope.getGlobalObject().set(name, *JSFn);
-
-            // Register C++ helper that retrieves the helper
-            // from the global object, converts the arguments,
-            // and invokes the JS function.
-            hbs_.registerHelper(name, dom::makeVariadicInvocable(
-                [this, name=std::string(name)](
-                    dom::Array const& args) -> Expected<dom::Value>
-                {
-                    // Get function from global scope
-                    js::Scope scope(ctx_);
-                    js::Value fn = scope.getGlobalObject().get(name);
-                    if (fn.isUndefined())
-                    {
-                        return Unexpected(Error("helper not found"));
-                    }
-                    if (!fn.isFunction())
-                    {
-                        return Unexpected(Error("helper is not a function"));
-                    }
-
-                    // Call function
-                    std::vector<dom::Value> arg_span;
-                    arg_span.reserve(args.size());
-                    for (auto const& arg : args)
-                    {
-                        arg_span.push_back(arg);
-                    }
-                    auto result = fn.apply(arg_span);
-                    if (!result)
-                    {
-                        return dom::Kind::Undefined;
-                    }
-
-                    // Convert result to dom::Value
-                    return result->getDom();
-                }));
-            return Error::success();
+            MRDOCS_TRY(auto script, files::getFileText(pathName));
+            MRDOCS_TRY(js::registerHelper(hbs_, name, ctx_, script));
+            return {};
         }).maybeThrow();
+
     hbs_.registerHelper(
         "is_multipage",
         dom::makeInvocable([res = config->multiPage]() -> Expected<dom::Value> {
         return res;
     }));
+
     hbs_.registerHelper("primary_location",
         dom::makeInvocable([](dom::Value const& v) ->
             dom::Value
@@ -162,6 +115,7 @@ Builder(
             }
             return first;
         }));
+
     helpers::registerStringHelpers(hbs_);
     helpers::registerAntoraHelpers(hbs_);
     helpers::registerContainerHelpers(hbs_);
@@ -183,8 +137,6 @@ callTemplate(
     MRDOCS_TRY(auto fileText, files::getFileText(pathName));
     HandlebarsOptions options;
     options.noEscape = true;
-    // options.compat = true;
-
     Expected<std::string, HandlebarsError> exp =
         hbs_.try_render(fileText, context, options);
     if (!exp)


### PR DESCRIPTION
This commit uses proxy objects to offer complete support for JavaScript helpers that return reference types. Previously, JavaScript reference types returned by these functions were deep-copied or not handled at all. Now, proxy objects in both directions are used while helpers create a scope that's kept alive as long as necessary by the Handlebars engine.

As the objects don't need to be deep copied, this change improves performance and allows objects with circular references, which are common in MrDocs. Additionally, JavaScript helpers receive a proxy object equivalent to the handlebars `options` object, and helper function registration was also simplified and improved to remove redundant code.

This commit provides new test cases to validate the current code without counting on MrDocs.