### PR TITLE
feat: templates have access to config

### DIFF
--- a/include/mrdocs/Config.hpp
+++ b/include/mrdocs/Config.hpp
@@ -34,6 +34,10 @@ class ThreadPool;
     A configuration is always connected to a
     particular directory from which absolute paths
     are calculated from relative paths.
+
+    The Config class is an abstract interface
+    whose concrete implementation includes
+    .
 */
 class MRDOCS_DECL
     Config
@@ -42,7 +46,8 @@ protected:
     Config() noexcept;
 
 public:
-
+    /** Settings values used to generate the Corpus and Docs
+     */
     struct Settings
     {
         /** Selected documentation generator.
@@ -115,13 +120,16 @@ public:
     ThreadPool&
     threadPool() const noexcept = 0;
 
+    /** Return the settings used to generate the Corpus and Docs.
+     */
+    virtual Settings const& settings() const noexcept = 0;
+
+    /// @copydoc settings()
     constexpr Settings const*
     operator->() const noexcept
     {
         return &settings();
     }
-
-    virtual Settings const& settings() const noexcept = 0;
 };
 
 } // mrdocs

--- a/include/mrdocs/Support/Path.hpp
+++ b/include/mrdocs/Support/Path.hpp
@@ -175,6 +175,8 @@ isDirsy(
 
     @li Separators made uniform
 
+    @li Separators are replaced with the native separator
+
     @return The normalized path.
 
     @param pathName The relative or absolute path.

--- a/share/mrdocs/addons/generator/asciidoc/partials/source.adoc.hbs
+++ b/share/mrdocs/addons/generator/asciidoc/partials/source.adoc.hbs
@@ -1,2 +1,1 @@
-// <{{dcl.file}}>: line {{dcl.line}}
-Declared in header <{{dcl.file}}>
+Declared in header `<{{#unless @root.config.baseURL}}{{dcl.file}}{{else}}{{@root.config.baseURL}}{{dcl.file}}#L{{dcl.line}}[{{dcl.file}},window=blank_]{{/unless}}>`

--- a/src/lib/Gen/adoc/Builder.cpp
+++ b/src/lib/Gen/adoc/Builder.cpp
@@ -203,6 +203,7 @@ public:
         auto* config_impl = dynamic_cast<ConfigImpl const*>(config_);
         if (config_impl)
         {
+            if (key == "baseURL") return (*config_impl)->baseURL;
             if (key == "inaccessibleBases") return (*config_impl)->inaccessibleBases;
             if (key == "inaccessibleMembers") return (*config_impl)->inaccessibleMembers;
             if (key == "anonymousNamespaces") return (*config_impl)->anonymousNamespaces;
@@ -233,6 +234,7 @@ public:
         auto* config_impl = dynamic_cast<ConfigImpl const*>(config_);
         if (config_impl)
         {
+            if (!fn("baseURL", (*config_impl)->baseURL)) { return false; };
             if (!fn("inaccessibleBases", (*config_impl)->inaccessibleBases)) { return false; };
             if (!fn("inaccessibleMembers", (*config_impl)->inaccessibleMembers)) { return false; };
             if (!fn("anonymousNamespaces", (*config_impl)->anonymousNamespaces)) { return false; };
@@ -250,7 +252,7 @@ public:
     /** Return the number of properties in the object.
      */
     std::size_t size() const override {
-        return 8;
+        return 9;
     };
 
     /** Determine if a key exists.
@@ -263,6 +265,7 @@ public:
         auto* config_impl = dynamic_cast<ConfigImpl const*>(config_);
         if (config_impl)
         {
+            if (key == "baseURL") return true;
             if (key == "inaccessibleBases") return true;
             if (key == "inaccessibleMembers") return true;
             if (key == "anonymousNamespaces") return true;

--- a/src/lib/Lib/ConfigImpl.cpp
+++ b/src/lib/Lib/ConfigImpl.cpp
@@ -100,6 +100,7 @@ struct llvm::yaml::MappingTraits<SettingsImpl>
         io.mapOptional("generate",          cfg.generate);
         io.mapOptional("multipage",         cfg.multiPage);
         io.mapOptional("source-root",       cfg.sourceRoot);
+        io.mapOptional("base-url",               cfg.baseURL);
 
         io.mapOptional("input",             cfg.input);
 
@@ -196,6 +197,12 @@ ConfigImpl(
     // Source root has to be forward slash style
     settings_.sourceRoot = files::makePosixStyle(files::makeDirsy(
         files::makeAbsolute(settings_.sourceRoot, settings_.workingDir)));
+
+    // Base-URL has to be dirsy with forward slash style
+    if (!settings_.baseURL.ends_with('/'))
+    {
+        settings_.baseURL.push_back('/');
+    }
 
     // Adjust input files
     for(auto& name : inputFileIncludes_)

--- a/src/lib/Lib/ConfigImpl.hpp
+++ b/src/lib/Lib/ConfigImpl.hpp
@@ -31,26 +31,18 @@ class ConfigImpl
 public:
     struct SettingsImpl : Settings
     {
-        struct FileFilter
-        {
-            std::vector<std::string> include;
-        };
+        /** Extraction policy for declarations.
 
-        struct Filters
-        {
-            struct Category
-            {
-                std::vector<std::string> include;
-                std::vector<std::string> exclude;
-            };
+            This determines how declarations are extracted.
 
-            Category symbols;
-        };
-
+         */
         enum class ExtractPolicy
         {
+            /// Always extract the declaration.
             Always,
+            /// Extract the declaration if it is referenced.
             Dependency,
+            /// Never extract the declaration.
             Never
         };
 
@@ -58,39 +50,18 @@ public:
 
             This determines how declarations which are referenced by
             explicitly extracted declarations are extracted.
-
-            Given a function parameter of type `std::string`, `std::string`
-            would be extracted if this option is set to `Policy::Always`.
-        */
+         */
         ExtractPolicy referencedDeclarations = ExtractPolicy::Dependency;
 
         /** Extraction policy for anonymous namespace.
-
-            @li `ExtractPolicy::Always`: anonymous namespaces and their
-            members will always be extracted.
-
-            @li `ExtractPolicy::Dependency`: members of anonymous namespaces will only
-            be extracted via dependency.
-
-            @li `ExtractPolicy::Never`: members of anonymous namespace will
-            never be extracted, regardless of how they are referenced.
-        */
+         */
         ExtractPolicy anonymousNamespaces = ExtractPolicy::Always;
 
         /** Extraction policy for inaccessible members.
-
-            @li `ExtractPolicy::Always`: all `private` and `protected` members
-            will be extracted.
-
-            @li `ExtractPolicy::Dependency`: `private` and `protected` members will only
-            be extracted via dependency.
-
-            @li `ExtractPolicy::Never`: `private` and `protected` will never be extracted.
-        */
+         */
         ExtractPolicy inaccessibleMembers = ExtractPolicy::Always;
 
         ExtractPolicy inaccessibleBases = ExtractPolicy::Always;
-
 
         /** Additional defines passed to the compiler.
         */
@@ -111,8 +82,34 @@ public:
         */
         std::string sourceRoot;
 
+        /** Specifies files that should be filtered
+        */
+        struct FileFilter
+        {
+            /// Directories to include
+            std::vector<std::string> include;
+        };
+
+        /// @copydoc FileFilter
         FileFilter input;
 
+        /** Specifies filters for various kinds of symbols.
+        */
+        struct Filters
+        {
+            /** Specifies inclusion and exclusion patterns
+            */
+            struct Category
+            {
+                std::vector<std::string> include;
+                std::vector<std::string> exclude;
+            };
+
+            /// Specifies filter patterns for symbols
+            Category symbols;
+        };
+
+        /// @copydoc Filters
         Filters filters;
 
         /** Symbol filter root node.
@@ -125,19 +122,19 @@ public:
 
     };
 
+    /// @copydoc Config::settings()
     Settings const&
-    settings()const noexcept override
+    settings() const noexcept override
     {
         return settings_;
     }
 
+    /// @copydoc Config::settings()
     constexpr SettingsImpl const*
     operator->() const noexcept
     {
         return &settings_;
     }
-
-    //--------------------------------------------
 
 private:
     SettingsImpl settings_;

--- a/src/lib/Lib/ConfigImpl.hpp
+++ b/src/lib/Lib/ConfigImpl.hpp
@@ -120,6 +120,12 @@ public:
         */
         FilterNode symbolFilter;
 
+        /** The base URL for the generated documentation.
+
+            This is used to generate links to sources
+            files referenced in the documentation.
+         */
+        std::string baseURL;
     };
 
     /// @copydoc Config::settings()

--- a/src/lib/Support/Path.cpp
+++ b/src/lib/Support/Path.cpp
@@ -212,8 +212,8 @@ makeDirsy(
     namespace path = llvm::sys::path;
 
     std::string result = static_cast<std::string>(pathName);
-    if( ! result.empty() &&
-        ! path::is_separator(
+    if (!result.empty() &&
+        !path::is_separator(
             result.back(),
             path::Style::windows_slash))
     {

--- a/src/tool/Addons.hpp
+++ b/src/tool/Addons.hpp
@@ -20,9 +20,11 @@ namespace mrdocs {
 
 /** Set the addons directory using the argument as a hint.
 
+
+
     @return The error if any occurred.
 */
-Error
+Expected<void>
 setupAddonsDir(
     llvm::cl::opt<std::string>& addonsDirArg,
     char const* argv0,


### PR DESCRIPTION
This PR gives templates access to the config values from mrdocs.yml. It also creates a new config key for setting the base URL so that the "Declared in header" templates can include a link to the declaration.