### PR TITLE
feat: input filters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,9 +255,6 @@ jobs:
       contents: write
 
     steps:
-      - name: Clone mrdocs
-        uses: actions/checkout@v3
-
       - uses: actions/download-artifact@v3
         with:
           name: release-packages-Linux
@@ -293,7 +290,7 @@ jobs:
         uses: alandefreitas/cpp-actions/boost-clone@v1.8.2
         id: boost-url-clone
         with:
-          branch: master
+          branch: develop
           modules: url
           boost-dir: boost
           modules-scan-paths: '"test example"'
@@ -302,28 +299,20 @@ jobs:
 
       - name: Generate demos
         run: |
-          config_template=$(printf '%s\n'                                      \
-            "verbose: true"                                                    \
-            "source-root: ."                                                   \
-            "base-url: 'https://github.com/boostorg/url/blob/master/include/'" \
-            "generate: %s"                                                     \
-            "multipage: %s"                                                    \
-            "inaccessible-members: never"                                      \
-            "inaccessible-bases: never"                                        \
-            "cmake: -D BOOST_URL_BUILD_TESTS=OFF -D BOOST_URL_BUILD_EXAMPLES=OFF -D CMAKE_EXPORT_COMPILE_COMMANDS=ON -D CMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES='$default_includes' -D CMAKE_CXX_COMPILER=${{ steps.setup-cpp.outputs.cxx  }} -D CMAKE_C_COMPILER=${{ steps.setup-cpp.outputs.cc  }}" \
-            "filters:"                                                         \
-            "  symbols:"                                                       \
-            "    exclude:"                                                     \
-            "      - 'boost::urls::detail'"                                    \
-            "      - 'boost::urls::*::detail'"                                 \
-          )
           set -x
+          CXX="${{ steps.setup-cpp.outputs.cxx }}"
+          export CXX
+          CC="${{ steps.setup-cpp.outputs.cc }}"
+          export CC
+          
           for variant in single multi; do
             for format in adoc html xml; do
-              [[ $variant = multi ]] && multiline="true" || multiline="false"
-              printf "$config_template\n" $format $multiline > $(pwd)/boost/libs/url/mrdocs.yml
+              [[ $variant = multi ]] && multipage="true" || multipage="false"
+              sed -i "s/^\(\s*multipage:\s*\).*\$/\1$multipage/" $(pwd)/boost/libs/url/doc/mrdocs.yml
+              sed -i "s/^\(\s*generate:\s*\).*\$/\1$format/" $(pwd)/boost/libs/url/doc/mrdocs.yml
+              cat $(pwd)/boost/libs/url/doc/mrdocs.yml
               mkdir -p "demos/boost-url/$variant/$format"
-              mrdocs --config="$(pwd)/boost/libs/url/mrdocs.yml" "$(pwd)/boost/libs/url/" --output="$(pwd)/demos/boost-url/$variant/$format"
+              mrdocs --config="$(pwd)/boost/libs/url/doc/mrdocs.yml" "$(pwd)/boost/libs/url/" --output="$(pwd)/demos/boost-url/$variant/$format"
             done
             asciidoctor -d book -R "$(pwd)/demos/boost-url/$variant/adoc" -D "$(pwd)/demos/boost-url/$variant/adoc-asciidoc" "$(pwd)/demos/boost-url/$variant/adoc/**/*.adoc"
           done

--- a/src/lib/Lib/ConfigImpl.hpp
+++ b/src/lib/Lib/ConfigImpl.hpp
@@ -96,6 +96,9 @@ public:
         {
             /// Directories to include
             std::vector<std::string> include;
+
+            /// File patterns
+            std::vector<std::string> filePatterns;
         };
 
         /// @copydoc FileFilter
@@ -158,7 +161,6 @@ private:
     SettingsImpl settings_;
     ThreadPool& threadPool_;
     llvm::SmallString<0> outputPath_;
-    std::vector<std::string> inputFileIncludes_;
     dom::Object configObj_;
 
     friend class Config;
@@ -194,7 +196,7 @@ public:
         to the file being processed.
     */
     bool
-    shouldVisitTU(
+    shouldVisitSymbol(
         llvm::StringRef filePath) const noexcept;
 
     /** Returns true if the file should be visited.

--- a/src/lib/Support/Glob.cpp
+++ b/src/lib/Support/Glob.cpp
@@ -1,0 +1,52 @@
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (c) 2024 Alan de Freitas (alandefreitas@gmail.com)
+//
+// Official repository: https://github.com/cppalliance/mrdocs
+//
+
+#include "Glob.hpp"
+
+namespace clang {
+namespace mrdocs {
+
+bool
+globMatch(
+    std::string_view pattern,
+    std::string_view str) noexcept
+{
+    if (pattern.empty())
+    {
+        return str.empty();
+    }
+    if (pattern[0] == '*')
+    {
+        if (pattern.size() == 1)
+        {
+            return true;
+        }
+        for (std::size_t i = 0; i <= str.size(); ++i)
+        {
+            if (globMatch(pattern.substr(1), str.substr(i)))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+    if (str.empty())
+    {
+        return false;
+    }
+    if (pattern[0] == str[0] || pattern[0] == '?')
+    {
+        return globMatch(pattern.substr(1), str.substr(1));
+    }
+    return false;
+}
+
+} // mrdocs
+} // clang

--- a/src/lib/Support/Glob.hpp
+++ b/src/lib/Support/Glob.hpp
@@ -1,0 +1,29 @@
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (c) 2024 Alan de Freitas (alandefreitas@gmail.com)
+//
+// Official repository: https://github.com/cppalliance/mrdocs
+//
+
+#ifndef MRDOCS_LIB_SUPPORT_GLOB_HPP
+#define MRDOCS_LIB_SUPPORT_GLOB_HPP
+
+#include <string>
+
+namespace clang {
+namespace mrdocs {
+
+/// Check if the string matches the glob pattern
+bool
+globMatch(
+    std::string_view pattern,
+    std::string_view str) noexcept;
+
+} // mrdocs
+} // clang
+
+#endif // MRDOCS_LIB_SUPPORT_GLOB_HPP
+


### PR DESCRIPTION
This PR implements the input filters needed by Boost.URL. 

Example:

```yaml
# Input
input:
  # Directories that contain documented source files
  include:
    - ../include
  # Patterns to filter out the source-files in the directories
  file-patterns:
    - '*.hpp'
```

which would be equivalent to the doxygen options `INPUT` and `FILE_PATTERNS`.