### PR TITLE
feat: support extra javadoc tags

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -17,7 +17,8 @@
         "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
         "LLVM_ROOT": "$env{LLVM_ROOT}",
         "Clang_ROOT": "$env{LLVM_ROOT}",
-        "MRDOCS_BUILD_TESTS": "ON"
+        "MRDOCS_BUILD_TESTS": "ON",
+        "VCPKG_MANIFEST_FEATURES": "tests"
       },
       "vendor": {
         "microsoft.com/VisualStudioSettings/CMake/1.0": {
@@ -56,7 +57,8 @@
       "description": "Release Config without Tests.",
       "binaryDir": "${sourceDir}/build/${presetName}",
       "cacheVariables": {
-        "MRDOCS_BUILD_TESTS": "OFF"
+        "MRDOCS_BUILD_TESTS": "OFF",
+        "VCPKG_MANIFEST_FEATURES": ""
       }
     }
   ]

--- a/include/mrdocs/Metadata/Javadoc.hpp
+++ b/include/mrdocs/Metadata/Javadoc.hpp
@@ -89,6 +89,13 @@ using List = std::vector<std::unique_ptr<T>>;
     Doxygen also introduces a number of additional tags on top
     of the the doc comment specification.
 
+    @note When a new tag is added, the `visit` function overloads
+    must be updated to handle the new tag. If the new object
+    contains new fields, `BitcodeWriter::emitBlock(doc::Node const& I)`
+    must include logic to serialize the new fields, and
+    `BitcodeReader::readBlock` must include logic to deserialize
+    the new fields.
+
     @see https://en.wikipedia.org/wiki/Javadoc[Javadoc - Wikipedia]
     @see https://docs.oracle.com/javase/1.5.0/docs/tooldocs/solaris/javadoc.html[Javadoc Documentation]
     @see https://docs.oracle.com/en/java/javase/13/docs/specs/javadoc/doc-comment-spec.html[Doc Comment Specification]

--- a/include/mrdocs/Metadata/Javadoc.hpp
+++ b/include/mrdocs/Metadata/Javadoc.hpp
@@ -848,6 +848,7 @@ struct Overview
     std::vector<Param const*> params;
     std::vector<TParam const*> tparams;
     std::vector<Throws const*> exceptions;
+    std::vector<See const*> sees;
 };
 
 MRDOCS_DECL dom::String toString(Style style) noexcept;

--- a/share/mrdocs/addons/generator/asciidoc/partials/symbols/record.adoc.hbs
+++ b/share/mrdocs/addons/generator/asciidoc/partials/symbols/record.adoc.hbs
@@ -25,4 +25,12 @@
 
 {{/if}}
 
-{{! TODO: == See Also }}
+{{#if symbol.doc.see}}
+== See Also
+
+{{#each symbol.doc.see}}
+{{.}}
+
+{{/each}}
+
+{{/if}}

--- a/src/lib/AST/AnyBlock.hpp
+++ b/src/lib/AST/AnyBlock.hpp
@@ -399,6 +399,12 @@ public:
             case doc::Kind::throws:
                 nodes.emplace_back(std::make_unique<doc::Throws>());
                 break;
+            case doc::Kind::details:
+                nodes.emplace_back(std::make_unique<doc::Details>());
+                break;
+            case doc::Kind::see:
+                nodes.emplace_back(std::make_unique<doc::See>());
+                break;
             default:
                 return formatError("unknown doc::Kind");
             }

--- a/src/lib/AST/ParseJavadoc.hpp
+++ b/src/lib/AST/ParseJavadoc.hpp
@@ -38,7 +38,16 @@ void
 initCustomCommentCommands(
     ASTContext& ctx);
 
-/** Parse a javadoc.
+/** Parse doc comments from a declaration
+
+    Parse the Javadoc from a declaration, populating the
+    Javadoc object with the parsed information.
+
+    @param jd The Javadoc object to populate
+    @param FC The full comment to parse
+    @param D The declaration to which the comment applies
+    @param config The MrDocs configuration object
+    @param diags The diagnostics object
 */
 void
 parseJavadoc(

--- a/src/lib/Gen/adoc/AdocCorpus.cpp
+++ b/src/lib/Gen/adoc/AdocCorpus.cpp
@@ -378,6 +378,18 @@ domCreate(
     return dom::Object(std::move(entries));
 }
 
+static
+dom::Value
+domCreate(
+    const doc::See& I,
+    const AdocCorpus& corpus)
+{
+    std::string s;
+    DocVisitor visitor(corpus, s);
+    visitor(static_cast<const doc::See&>(I));
+    return s;
+}
+
 //------------------------------------------------
 
 class DomJavadoc : public dom::LazyObjectImpl
@@ -464,6 +476,7 @@ public:
         maybeEmplaceArray(list, "params", ov.params);
         maybeEmplaceArray(list, "tparams", ov.tparams);
         maybeEmplaceArray(list, "exceptions", ov.exceptions);
+        maybeEmplaceArray(list, "see", ov.sees);
 
         return dom::Object(std::move(list));
     }

--- a/src/lib/Gen/adoc/Options.cpp
+++ b/src/lib/Gen/adoc/Options.cpp
@@ -132,8 +132,11 @@ loadOptions(
     }
     else
     {
-        // VFALCO TODO get process executable
-        // and form a path relative to that.
+        opt.template_dir = files::makeDirsy(files::appendPath(
+            corpus.config->addonsDir,
+            "generator",
+            "asciidoc"
+        ));
     }
 
     if(! opt.template_dir.empty())
@@ -145,8 +148,11 @@ loadOptions(
     }
     else
     {
-        // VFALCO TODO get process executable
-        // and form a path relative to that.
+        opt.template_dir = files::makeDirsy(files::appendPath(
+            corpus.config->addonsDir,
+            "generator",
+            "asciidoc"
+        ));
     }
 
     return opt;

--- a/src/lib/Gen/xml/XMLWriter.cpp
+++ b/src/lib/Gen/xml/XMLWriter.cpp
@@ -622,49 +622,55 @@ writeNode(
     switch(node.kind)
     {
     case doc::Kind::text:
-        writeText(static_cast<doc::Text const&>(node));
+        writeText(dynamic_cast<doc::Text const&>(node));
         break;
     case doc::Kind::styled:
-        writeStyledText(static_cast<doc::Styled const&>(node));
+        writeStyledText(dynamic_cast<doc::Styled const&>(node));
         break;
     case doc::Kind::heading:
-        writeHeading(static_cast<doc::Heading const&>(node));
+        writeHeading(dynamic_cast<doc::Heading const&>(node));
         break;
     case doc::Kind::paragraph:
-        writeParagraph(static_cast<doc::Paragraph const&>(node));
+        writeParagraph(dynamic_cast<doc::Paragraph const&>(node));
         break;
     case doc::Kind::link:
-        writeLink(static_cast<doc::Link const&>(node));
+        writeLink(dynamic_cast<doc::Link const&>(node));
         break;
     case doc::Kind::list_item:
-        writeListItem(static_cast<doc::ListItem const&>(node));
+        writeListItem(dynamic_cast<doc::ListItem const&>(node));
         break;
     case doc::Kind::brief:
-        writeBrief(static_cast<doc::Brief const&>(node));
+        writeBrief(dynamic_cast<doc::Brief const&>(node));
         break;
     case doc::Kind::admonition:
-        writeAdmonition(static_cast<doc::Admonition const&>(node));
+        writeAdmonition(dynamic_cast<doc::Admonition const&>(node));
         break;
     case doc::Kind::code:
-        writeCode(static_cast<doc::Code const&>(node));
+        writeCode(dynamic_cast<doc::Code const&>(node));
         break;
     case doc::Kind::param:
-        writeJParam(static_cast<doc::Param const&>(node));
+        writeJParam(dynamic_cast<doc::Param const&>(node));
         break;
     case doc::Kind::tparam:
-        writeTParam(static_cast<doc::TParam const&>(node));
+        writeTParam(dynamic_cast<doc::TParam const&>(node));
         break;
     case doc::Kind::returns:
-        writeReturns(static_cast<doc::Returns const&>(node));
+        writeReturns(dynamic_cast<doc::Returns const&>(node));
         break;
     case doc::Kind::reference:
-        writeReference(static_cast<doc::Reference const&>(node));
+        writeReference(dynamic_cast<doc::Reference const&>(node));
         break;
     case doc::Kind::copied:
-        writeCopied(static_cast<doc::Copied const&>(node));
+        writeCopied(dynamic_cast<doc::Copied const&>(node));
         break;
     case doc::Kind::throws:
-        writeThrows(static_cast<doc::Throws const&>(node));
+        writeThrows(dynamic_cast<doc::Throws const&>(node));
+        break;
+    case doc::Kind::details:
+        writeDetails(dynamic_cast<doc::Details const&>(node));
+        break;
+    case doc::Kind::see:
+        writeSee(dynamic_cast<doc::See const&>(node));
         break;
     default:
         // unknown kind
@@ -774,6 +780,30 @@ writeParagraph(
         { "class", tag, ! tag.empty() }});
     writeNodes(para.children);
     tags_.close("para");
+}
+
+void
+XMLWriter::
+writeDetails(
+    doc::Details const& para,
+    llvm::StringRef tag)
+{
+    tags_.open("details", {
+        { "class", tag, ! tag.empty() }});
+    writeNodes(para.children);
+    tags_.close("details");
+}
+
+void
+XMLWriter::
+writeSee(
+    doc::See const& para,
+    llvm::StringRef tag)
+{
+    tags_.open("see", {
+        { "class", tag, ! tag.empty() }});
+    writeNodes(para.children);
+    tags_.close("see");
 }
 
 void

--- a/src/lib/Gen/xml/XMLWriter.hpp
+++ b/src/lib/Gen/xml/XMLWriter.hpp
@@ -97,6 +97,8 @@ public:
     void writeReference(doc::Reference const& node);
     void writeCopied(doc::Copied const& node);
     void writeThrows(doc::Throws const& node);
+    void writeDetails(doc::Details const& node, llvm::StringRef tag = "");
+    void writeSee(doc::See const& node, llvm::StringRef tag = "");
 };
 
 } // xml

--- a/src/lib/Metadata/Javadoc.cpp
+++ b/src/lib/Metadata/Javadoc.cpp
@@ -274,6 +274,10 @@ makeOverview(
             ov.exceptions.push_back(static_cast<
                 doc::Throws const*>(it->get()));
             break;
+        case doc::Kind::see:
+            ov.sees.push_back(static_cast<
+                doc::See const*>(it->get()));
+            break;
         default:
             if(ov.brief == it->get())
                 break;


### PR DESCRIPTION
This PR includes support for tags that are used in Boost.URL but are currently ignored by MrDocs.