### PR TITLE
Use official dependency releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,15 +56,6 @@ jobs:
       contents: write
 
     steps:
-      - name: Install Essential Packages
-        if: ${{ matrix.container }}
-        env:
-          DEBIAN_FRONTEND: 'noninteractive'
-          TZ: 'Etc/UTC'
-        uses: alandefreitas/cpp-actions/package-install@v1.8.2
-        with:
-          apt-get: git build-essential python3
-
       - name: Clone MrDocs
         uses: actions/checkout@v3
 
@@ -72,7 +63,6 @@ jobs:
         uses: alandefreitas/cpp-actions/setup-cmake@v1.8.2
         id: setup-cmake
         with:
-          # Clang requires clang-scan-deps to work on the latest CMake versions
           version: ${{ matrix.compiler == 'clang' && '3.26' || '>=3.26' }}
           check-latest: 'true'
           update-environment: 'true'
@@ -80,6 +70,82 @@ jobs:
       - name: Setup Ninja
         uses: seanmiddleditch/gha-setup-ninja@v4
         if: ${{ runner.os == 'Windows' }}
+
+      - name: Setup C++
+        uses: alandefreitas/cpp-actions/setup-cpp@v1.8.2
+        id: setup-cpp
+        with:
+          compiler: ${{ matrix.compiler }}
+          version: ${{ matrix.version }}
+          check-latest: ${{ matrix.compiler == 'clang' }}
+
+      - name: Install System Packages
+        uses: alandefreitas/cpp-actions/package-install@v1.8.2
+        id: package-install
+        env:
+          DEBIAN_FRONTEND: 'noninteractive'
+          TZ: 'Etc/UTC'
+        with:
+          apt-get: ${{ matrix.install }} git build-essential python3 curl openjdk-11-jdk ninja-build pkg-config libncurses-dev
+          vcpkg: libxml2[tools]
+          cc: ${{ steps.setup-cpp.outputs.cc || matrix.cc }}
+          ccflags: ${{ matrix.ccflags }}
+          cxx: ${{ steps.setup-cpp.outputs.cxx || matrix.cxx }}
+          cxxflags: ${{ matrix.cxxflags }}
+
+      - name: Install Fmt
+        id: fmt-install
+        shell: bash
+        run: |
+          set -x
+          cd ..
+          mkdir -p third-party
+          cd third-party
+          git clone https://github.com/fmtlib/fmt --branch 10.2.1 --depth 1
+          cd fmt
+          cmake -S . -B ./build -D FMT_DOC=OFF -D FMT_TEST=OFF -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} -DCMAKE_CXX_COMPILER=${{ steps.setup-cpp.outputs.cxx }} -DCMAKE_C_COMPILER=${{ steps.setup-cpp.outputs.cc }}
+          N_CORES=$(nproc 2>/dev/null || echo 1)
+          cmake --build ./build --config ${{ matrix.build-type }} --parallel $N_CORES 
+          cmake --install ./build --prefix ./install
+          
+          fmt_root=$(pwd)/install
+          if [[ ${{ runner.os }} == 'Windows' ]]; then
+              fmt_root=$(echo "$fmt_root" | sed 's/\\/\//g')
+              fmt_root=$(echo $fmt_root | sed 's|^/d/|D:/|')
+              echo "$fmt_root"
+          fi
+          echo -E "fmt-root=$fmt_root" >> $GITHUB_OUTPUT
+
+      - name: Install Duktape
+        id: duktape-install
+        shell: bash
+        run: |
+          set -x
+          cd ..
+          mkdir -p third-party
+          cd third-party
+          curl -LJO https://github.com/svaarala/duktape/releases/download/v2.7.0/duktape-2.7.0.tar.xz
+          tar -xf duktape-2.7.0.tar.xz
+          cp ../mrdocs/third-party/duktape/CMakeLists.txt ./duktape-2.7.0/CMakeLists.txt
+          cp ../mrdocs/third-party/duktape/duktapeConfig.cmake.in ./duktape-2.7.0/duktapeConfig.cmake.in
+          cd duktape-2.7.0
+          if [[ "${{ matrix.shared && 'true' || 'false' }}" == 'true' ]]; then
+              sed -i 's/#undef DUK_F_DLL_BUILD/#define DUK_F_DLL_BUILD/g' "src/duk_config.h"
+          else
+              sed -i 's/#define DUK_F_DLL_BUILD/#undef DUK_F_DLL_BUILD/g' "src/duk_config.h"
+          fi
+          cmake -S . -B ./build -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} -DCMAKE_CXX_COMPILER=${{ steps.setup-cpp.outputs.cxx }} -DCMAKE_C_COMPILER=${{ steps.setup-cpp.outputs.cc }}
+          N_CORES=$(nproc 2>/dev/null || echo 1)
+          cmake --build ./build --config ${{ matrix.build-type }} --parallel $N_CORES 
+          cmake --install ./build --prefix ./install
+          
+          duktape_root=$(pwd)/install
+          if [[ ${{ runner.os }} == 'Windows' ]]; then
+              duktape_root=$(echo "$duktape_root" | sed 's/\\/\//g')
+              duktape_root=$(echo $duktape_root | sed 's|^/d/|D:/|')
+              echo "$duktape_root"
+          fi
+          echo -E "duktape-root=$duktape_root" >> $GITHUB_OUTPUT
 
       - name: LLVM Parameters
         id: llvm-parameters
@@ -100,7 +166,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ steps.llvm-parameters.outputs.llvm-root }}
-          key: llvm-${{ runner.os }}-${{ steps.llvm-parameters.outputs.llvm-build-preset }}-${{ steps.llvm-parameters.outputs.llvm-hash }}
+          key: llvm-${{ runner.os }}-${{ matrix.compiler }}-${{ matrix.version }}-${{ steps.llvm-parameters.outputs.llvm-build-preset }}-${{ steps.llvm-parameters.outputs.llvm-hash }}
 
       - name: Install LLVM
         id: llvm-install
@@ -130,34 +196,13 @@ jobs:
           cd llvm
           llvm_root=$(pwd)
           cmake --version
-          cmake -S . -B ./build --preset=${{ steps.llvm-parameters.outputs.llvm-build-preset }}
+          cmake -S . -B ./build --preset=${{ steps.llvm-parameters.outputs.llvm-build-preset }} -DCMAKE_CXX_COMPILER=${{ steps.setup-cpp.outputs.cxx }} -DCMAKE_C_COMPILER=${{ steps.setup-cpp.outputs.cc }}
           if [[ ${{ runner.os }} == 'Linux' ]]; then
               cmake --build ./build --target help
           fi          
           N_CORES=$(nproc 2>/dev/null || echo 1)
           cmake --build ./build --config Release --parallel $N_CORES 
           cmake --install ./build --prefix "$llvm_project_root"/install
-           
-      # Setup C++ after installing LLVM to use the default compiler
-      # for LLVM and the specified compiler for MrDocs
-      - name: Setup C++
-        uses: alandefreitas/cpp-actions/setup-cpp@v1.8.2
-        id: setup-cpp
-        with:
-          compiler: ${{ matrix.compiler }}
-          version: ${{ matrix.version }}
-          check-latest: ${{ matrix.compiler == 'clang' }}
-
-      - name: Install packages
-        uses: alandefreitas/cpp-actions/package-install@v1.8.2
-        id: package-install
-        with:
-          apt-get: ${{ matrix.install }} openjdk-11-jdk ninja-build pkg-config libncurses-dev
-          vcpkg: fmt duktape libxml2[tools]
-          cc: ${{ steps.setup-cpp.outputs.cc || matrix.cc }}
-          ccflags: ${{ matrix.ccflags }}
-          cxx: ${{ steps.setup-cpp.outputs.cxx || matrix.cxx }}
-          cxxflags: ${{ matrix.cxxflags }}
 
       - name: Install Node.js
         uses: actions/setup-node@v3
@@ -167,7 +212,7 @@ jobs:
       - name: CMake Workflow
         uses: alandefreitas/cpp-actions/cmake-workflow@v1.8.2
         with:
-          cmake-version: '>=3.20'
+          cmake-version: ${{ matrix.compiler == 'clang' && '3.26' || '>=3.26' }}
           cxxstd: ${{ matrix.cxxstd }}
           cc: ${{ steps.setup-cpp.outputs.cc || matrix.cc }}
           ccflags: ${{ matrix.ccflags }}${{ ( matrix.compiler == 'gcc' && ' -static-libstdc++') || '' }}${{ ( matrix.asan && ' -static-libasan') || '' }}${{ ( matrix.tsan && ' -static-libtsan') || '' }}
@@ -178,8 +223,12 @@ jobs:
           build-type: ${{ matrix.build-type }}
           install-prefix: .local
           extra-args: |
-            -D LLVM_ROOT="${{ steps.llvm-parameters.outputs.llvm-root || '../third-party/llvm-project/install' }}"
-            -D Clang_ROOT="${{ steps.llvm-parameters.outputs.llvm-root || '../third-party/llvm-project/install' }}"
+            -D MRDOCS_BUILD_DOCS=OFF
+            -D LLVM_ROOT=${{ steps.llvm-parameters.outputs.llvm-root }}
+            -D Clang_ROOT=${{ steps.llvm-parameters.outputs.llvm-root }}
+            -D duktape_ROOT=${{ steps.duktape-install.outputs.duktape-root }}
+            -D Duktape_ROOT=${{ steps.duktape-install.outputs.duktape-root }}
+            -D fmt_ROOT=${{ steps.fmt-install.outputs.fmt-root }}
           export-compile-commands: true
           run-tests: true
           install: true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,15 +99,17 @@ llvm_map_components_to_libnames(llvm_libs all)
 string(REGEX REPLACE " /W[0-4]" "" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
 string(REGEX REPLACE " /W[0-4]" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
 
-# Duktape
-set(DUKTAPE_PACKAGE_NAME duktape)
-if (WIN32)
-    set(DUKTAPE_PACKAGE_NAME Duktape)
-endif()
-find_package(${DUKTAPE_PACKAGE_NAME} REQUIRED)
-
 # fmt
 find_package(fmt REQUIRED CONFIG)
+
+# Duktape
+find_package(duktape CONFIG)
+if (NOT DUKTAPE_FOUND)
+    # Duktape doesn't nativelly support CMake.
+    # Some config script patches use the capitalized version.
+    find_package(Duktape REQUIRED CONFIG)
+endif()
+
 unset(CMAKE_FOLDER)
 
 #-------------------------------------------------

--- a/docs/antora-playbook.yml
+++ b/docs/antora-playbook.yml
@@ -21,6 +21,27 @@ ui:
   bundle:
     url: https://gitlab.com/antora/antora-ui-default/-/jobs/artifacts/HEAD/raw/build/ui-bundle.zip?job=bundle-stable
     snapshot: true
+  supplemental_files:
+    - path: css/vendor/tabs.css
+      contents: ./node_modules/@asciidoctor/tabs/dist/css/tabs.css
+    - path: js/vendor/tabs.js
+      contents: ./node_modules/@asciidoctor/tabs/dist/js/tabs.js
+    - path: partials/footer-scripts.hbs
+      contents: |
+        <script id="site-script" src="{{{uiRootPath}}}/js/site.js" data-ui-root-path="{{{uiRootPath}}}"></script>
+        <script async src="{{{uiRootPath}}}/js/vendor/highlight.js"></script>
+        <script async src="{{{uiRootPath}}}/js/vendor/tabs.js"></script>
+        {{#if env.SITE_SEARCH_PROVIDER}}
+        {{> search-scripts}}
+        {{/if}}
+    - path: partials/head-styles.hbs
+      contents: |
+        <link rel="stylesheet" href="{{{uiRootPath}}}/css/site.css">
+        <link rel="stylesheet" href="{{{uiRootPath}}}/css/vendor/tabs.css">
+
+asciidoc:
+  extensions:
+    - '@asciidoctor/tabs'
 
 antora:
   extensions:

--- a/docs/local-antora-playbook.yml
+++ b/docs/local-antora-playbook.yml
@@ -18,6 +18,29 @@ ui:
   bundle:
     url: https://gitlab.com/antora/antora-ui-default/-/jobs/artifacts/HEAD/raw/build/ui-bundle.zip?job=bundle-stable
     snapshot: true
+  supplemental_files:
+    - path: css/vendor/tabs.css
+      contents: ./node_modules/@asciidoctor/tabs/dist/css/tabs.css
+    - path: js/vendor/tabs.js
+      contents: ./node_modules/@asciidoctor/tabs/dist/js/tabs.js
+    - path: partials/footer-scripts.hbs
+      contents: |
+        <script id="site-script" src="{{{uiRootPath}}}/js/site.js" data-ui-root-path="{{{uiRootPath}}}"></script>
+        <script async src="{{{uiRootPath}}}/js/vendor/highlight.js"></script>
+        <script async src="{{{uiRootPath}}}/js/vendor/tabs.js"></script>
+        {{#if env.SITE_SEARCH_PROVIDER}}
+        {{> search-scripts}}
+        {{/if}}
+    - path: partials/head-styles.hbs
+      contents: |
+        <link rel="stylesheet" href="{{{uiRootPath}}}/css/site.css">
+        <link rel="stylesheet" href="{{{uiRootPath}}}/css/vendor/tabs.css">
+
+asciidoc:
+  extensions:
+    - '@asciidoctor/tabs'
+
+
 
 antora:
   extensions:

--- a/docs/modules/ROOT/pages/install.adoc
+++ b/docs/modules/ROOT/pages/install.adoc
@@ -3,8 +3,10 @@
 [#mrdocs-binaries]
 == Binaries
 
-Binary packages are available from our https://github.com/cppalliance/mrdocs/releases[Release Page,window="_blank"]
+Binary packages are available from our https://github.com/cppalliance/mrdocs/releases[Release Page,window="_blank"].
+Most users should use these packages.
 
+[#mrdocs-source]
 == Source
 
 The following instructions assume we are at a parent directory that's going to contain both the MrDocs and the third-party dependencies directories.
@@ -37,24 +39,230 @@ These instructions assume all dependencies are installed in the `third-party` di
 Fell free to install them anywhere you want and adjust the main MrDocs configuration command later.
 ====
 
-=== Installing LLVM
+[#install-fmt]
+=== Fmt
+
+MrDocs uses the `fmt` library for formatting strings.
+From the `third-party` directory, you can clone the `fmt` repository and install it with the following commands:
+
+[source,bash]
+----
+git clone https://github.com/fmtlib/fmt --branch 10.2.1 --depth 1 <.>
+cd fmt
+cmake -S . -B ./build -DCMAKE_BUILD_TYPE=Release -D FMT_DOC=OFF -D FMT_TEST=OFF <.>
+cmake --build ./build --config Release <.>
+cmake --install ./build --prefix ./install <.>
+cd ..
+----
+
+<.> Shallow clones the fmt repository.
+<.> Configure the fmt library with CMake, exclusing the documentation and tests.
+<.> Builds the fmt library in the `build` directory.
+<.> Installs the fmt library in the `install` directory.
+
+[IMPORTANT]
+====
+All instructions in this document assume you are using a CMake version above 3.26.
+Binaries are available at https://cmake.org/download/[CMake's official website,window="_blank"].
+====
+
+If you prefer using Vcpkg to install dependencies, you can install VcPkg and `fmt` with the following commands from the `third-party` directory:
+
+:tabs-sync-option:
+
+[tabs]
+====
+Windows PowerShell::
++
+--
+[source,bash]
+----
+git clone https://github.com/microsoft/vcpkg.git -b master <.>
+cd vcpkg
+bootstrap-vcpkg.bat <.>
+vcpkg.exe fmt --triplet x64-windows <.>
+----
+
+<.> Clones the Vcpkg repository.
+<.> Bootstraps Vcpkg.
+<.> Installs the `fmt` library.
+--
+
+Unix Variants::
++
+--
+[source,bash]
+----
+git clone https://github.com/microsoft/vcpkg.git -b master <.>
+cd vcpkg
+./bootstrap-vcpkg.sh <.>
+./vcpkg fmt <.>
+----
+
+<.> Clones the Vcpkg repository.
+<.> Bootstraps Vcpkg.
+<.> Installs the `fmt` library.
+--
+====
+
+[NOTE]
+====
+You can also install `fmt` with Vcpkg in _Manifest mode_.
+In https://learn.microsoft.com/en-us/vcpkg/users/manifests[manifest mode,windows=blank_], you declare your project's direct dependencies in a manifest file named `vcpkg.json`.
+MrDocs includes a `vcpkg.json.example` file you can duplicate or create a symlink as `vcpkg.json` to use this mode.
+This file includes all the dependencies MrDocs needs, except for LLVM.
+
+In this mode, VcPkg will create separate installed trees for each project and configuration.
+This is the recommended vcpkg mode for most users, according to the https://learn.microsoft.com/en-us/vcpkg/users/manifests[vcpkg documentation,window=blank_].
+====
+
+=== Duktape
+
+MrDocs uses the `duktape` library for JavaScript parsing.
+From the `third-party` directory, you can download the `duktape` source code from the official release:
+
+[tabs]
+====
+Windows PowerShell::
++
+--
+[source,bash]
+----
+Invoke-WebRequest -Uri "https://github.com/svaarala/duktape/releases/download/v2.7.0/duktape-2.7.0.tar.xz" -OutFile "duktape-2.7.0.tar.xz"
+----
+
+<.> Downloads the `duktape` source code.
+--
+
+Unix Variants::
++
+--
+[source,bash]
+----
+curl -LJO https://github.com/svaarala/duktape/releases/download/v2.7.0/duktape-2.7.0.tar.xz <.>
+----
+
+<.> Downloads the `duktape` source code.
+--
+====
+
+Then patch the Duktape source code to provide CMake support.
+
+[source,bash]
+----
+tar -xf duktape-2.7.0.tar.xz <.>
+cp ../mrdocs/third-party/duktape/CMakeLists.txt ./duktape-2.7.0/CMakeLists.txt <.>
+cp ../mrdocs/third-party/duktape/duktapeConfig.cmake.in ./duktape-2.7.0/duktapeConfig.cmake.in <.>
+cd duktape-2.7.0
+----
+
+<.> Extracts the `duktape` source code.
+<.> Patches the source code with a `CMakeLists.txt` file to the `duktape-2.7.0` directory so that we can build it with CMake.
+<.> Copies the `duktapeConfig.cmake.in` file to the `duktape-2.7.0` directory so that we can install it with CMake and find it later from other CMake projects.
+
+Now adjust the `duk_config.h` file to indicate we are statically building Duktape.
+
+[tabs]
+====
+Windows PowerShell::
++
+--
+[source,bash]
+----
+$content = Get-Content -Path "src\duk_config.h"
+$content = $content -replace '#define DUK_F_DLL_BUILD', '#undef DUK_F_DLL_BUILD'
+$content | Set-Content -Path "src\duk_config.h"
+----
+
+<.> Read the content of `duk_config.h`
+<.> Replace the `DUK_F_DLL_BUILD` macro with `#undef DUK_F_DLL_BUILD`
+<.> Write the content back to the file
+--
+
+Unix Variants::
++
+--
+[source,bash]
+----
+sed -i 's/#define DUK_F_DLL_BUILD/#undef DUK_F_DLL_BUILD/g' "src/duk_config.h" <.>
+----
+
+<.> Disables the `DUK_F_DLL_BUILD` macro in the `duk_config.h` file to indicate we are statically building duktape.
+--
+====
+
+And finally install the library with CMake:
+
+[source,bash]
+----
+cmake -S . -B ./build -DCMAKE_BUILD_TYPE=Release <.>
+cmake --build ./build --config Release <.>
+cmake --install ./build --prefix ./install <.>
+----
+
+<.> Configures the `duktape` library with CMake.
+<.> Builds the `duktape` library in the `build` directory.
+<.> Installs the `duktape` library with CMake support in the `install` directory.
+
+The scripts above downloads the `duktape` source code, extracts it, and configures it with CMake.
+The CMake scripts provided by MrDocs are copied to the `duktape-2.7.0` directory to facilitate the build process with CMake and provide CMake installation scripts for other projects.
+
+If you prefer using Vcpkg to install dependencies, you can install `duktape` with the following commands from the `third-party` directory:
+
+[tabs]
+====
+Windows PowerShell::
++
+--
+[source,bash]
+----
+cd vcpkg
+vcpkg.exe duktape --triplet x64-windows <.>
+----
+
+<.> Installs the `duktape` library.
+--
+
+Unix Variants::
++
+--
+[source,bash]
+----
+cd vcpkg
+./vcpkg duktape <.>
+----
+
+<.> Installs the `duktape` library.
+--
+====
+
+NOTE: These examples assume VcPkg is already installed in the `third-party/vcpkg` directory (see the <<install-fmt>> section).
+
+=== LLVM
 
 MrDocs uses LLVM to parse C++ code and extract documentation from it.
 It depends on a recent version of LLVM: https://github.com/llvm/llvm-project/tree/29b20829cc6ce3e6d9c3809164994c1659e0da56[29b20829]
 
 **Download**:
 
-You can shallow-clone the project from the official repository:
+You can shallow-clone the project from the official repository.
+From the `third-party` directory, run the following commands:
 
 [source,bash]
 ----
-mkdir -p llvm-project
+mkdir -p llvm-project <.>
 cd llvm-project
-git init
-git remote add origin https://github.com/llvm/llvm-project.git
-git fetch --depth 1 origin 29b20829cc6ce3e6d9c3809164994c1659e0da56
-git checkout FETCH_HEAD
+git init <.>
+git remote add origin https://github.com/llvm/llvm-project.git <.>
+git fetch --depth 1 origin 29b20829cc6ce3e6d9c3809164994c1659e0da56 <.>
+git checkout FETCH_HEAD <.>
 ----
+
+<.> Create a directory for the llvm-project instead of cloning it
+<.> Initialize a git repository
+<.> Add the official LLVM repository as a remote
+<.> Fetch the commit we want to use: this allows us to shallow-clone the repository at this commit
+<.> Checkout the commit we want to use
 
 **Configure**:
 
@@ -70,11 +278,28 @@ cp ../../mrdocs/third-party/llvm/CMakeUserPresets.json.example ./llvm/CMakeUserP
 
 Run a command such as the following to configure LLVM:
 
+[tabs]
+====
+Windows PowerShell::
++
+--
 [source,bash]
 ----
 cd llvm
 cmake -S . -B ./build --preset=release-win
 ----
+--
+
+Unix Variants::
++
+--
+[source,bash]
+----
+cd llvm
+cmake -S . -B ./build --preset=release-unix
+----
+--
+====
 
 In the example above, we configure a `Release` version of LLVM for MrDocs.
 Choose one of the presets from `CMakePresets.json` or edit the variants in `CMakeUserPresets.json` to customize the configurations.
@@ -101,88 +326,39 @@ cmake --install ./build --prefix ../install
 
 Replace 4 with the number of cores you want to use for building LLVM.
 
-Return from `./third-party/llvm-project/llvm` to the parent `third-party` directory to install other dependencies:
+Return from `./third-party/llvm-project/llvm` to the parent directory to build and install MrDocs:
 
 [source,bash]
 ----
-cd ../..
+cd ../../..
 ----
 
-=== CMake dependencies
+=== Libxml2
 
-All other dependencies provide CMake integration scripts and can be obtained from https://www.vcpkg.io/[vcpkg] or installed manually.
+Developers should also install the `libxml2` tools to parse XML files.
+This tool is used in tests.
+You can install the libxml2 tools with Vcpkg:
 
-* `fmt` >= 10
-* `duktape`
-
-For development builds, which include tests, you will also need:
-
-* `libxml2[tools]`
-
-The instructions in this documentation will use vcpkg for these.
-
-**Installing vcpkg**:
-
-If you don't have vcpkg installed, clone the repository:
-
+[tabs]
+====
+Windows PowerShell::
++
+--
 [source,bash]
 ----
-git clone https://github.com/microsoft/vcpkg.git -b master
-cd vcpkg
+vcpkg.exe libxml2[tools] --triplet x64-windows
 ----
+--
 
-and bootstrap it:
-
-Windows:
-
+Unix Variants::
++
+--
 [source,bash]
 ----
-bootstrap-vcpkg.bat
+./vcpkg libxml2[tools]
 ----
-
-Unix variants:
-
-[source,bash]
-----
-./bootstrap-vcpkg.sh
-----
-
-**Installing dependencies**:
-
-vcpkg has two operation modes with which you can install these dependencies: <<vcpkg-classic-mode,classic mode>> and <<vcpkg-manifest-mode,manifest mode>>.
-
-[#vcpkg-classic-mode]
-_Classic mode_:
-
-In vcpkg https://learn.microsoft.com/en-us/vcpkg/users/classic-mode[classic mode,window=blank_], vcpkg maintains a central installed tree inside the vcpkg instance built up by individual `vcpkg install` and `vcpkg remove` commands.
-This central set of packages can then be shared by any number of projects.
-However, each instance of vcpkg (a separate git clone) will have its own set of packages installed.
-
-To install these dependencies with vcpkg in classic mode:
-
-Windows:
-
-[source,bash]
-----
-vcpkg.exe fmt zlib libxml2[tools] --triplet x64-windows
-----
-
-Unix variants:
-
-[source,bash]
-----
-./vcpkg fmt zlib libxml2[tools]
-----
-
-[#vcpkg-manifest-mode]
-_Manifest mode_:
-
-In https://learn.microsoft.com/en-us/vcpkg/users/manifests[manifest mode,windows=blank_], you declare your project's direct dependencies in a manifest file named `vcpkg.json`.
-MrDocs includes a `vcpkg.json.example` file you can duplicate or create a symlink as `vcpkg.json` to use this mode.
-MrDocs is a CMake project that then already includes a `vcpkg.json` file, there's nothing else you need to run to install the dependencies.
-
-In this mode, vcpkg will create separate installed trees for each project and configuration.
-This is the recommended vcpkg mode for most users according to the https://learn.microsoft.com/en-us/vcpkg/users/manifests[vcpkg documentation,window=blank_].
+--
+====
 
 === MrDocs
 
@@ -202,19 +378,26 @@ _Configure with Command Line Arguments_:
 
 With the dependencies are available in `third-party`, you can configure MrDocs with:
 
-Windows:
-
+[tabs]
+====
+Windows PowerShell::
++
+--
 [source,commandline]
 ----
 cmake -S mrdocs -B build -G "Visual Studio 17 2022" -A x64 -D CMAKE_CONFIGURATION_TYPES="RelWithDebInfo" -D CMAKE_EXPORT_COMPILE_COMMANDS=ON -D LLVM_ROOT="%cd%/third-party/llvm+clang/RelWithDebInfo" -D DUKTAPE_SOURCE_ROOT="%cd%/third-party/duktape-2.7.0" -D CMAKE_TOOLCHAIN_FILE="%cd%/third-party/vcpkg/scripts/buildsystems/vcpkg.cmake"
 ----
+--
 
-Unix variants:
-
+Unix Variants::
++
+--
 [source,bash]
 ----
 cmake -S mrdocs -B build -D CMAKE_BUILD_TYPE=RelWithDebInfo -D CMAKE_EXPORT_COMPILE_COMMANDS=ON -D LLVM_ROOT="$(pwd)/third-party/llvm+clang/RelWithDebInfo" -D DUKTAPE_SOURCE_ROOT="$(pwd)/third-party/duktape-2.7.0" -D CMAKE_TOOLCHAIN_FILE="$(pwd)/third-party/vcpkg/scripts/buildsystems/vcpkg.cmake"
 ----
+--
+====
 
 [#mrdocs-configure-presets]
 _Configure with CMake Presets_:

--- a/third-party/duktape/CMakeLists.txt
+++ b/third-party/duktape/CMakeLists.txt
@@ -1,0 +1,70 @@
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# Copyright (c) 2024 Alan de Freitas (alandefreitas@gmail.com)
+#
+# Official repository: https://github.com/cppalliance/mrdocs
+#
+#
+
+#
+# This file is derived from the CMakeLists.txt file in the Microsoft vcpkg repository:
+# https://github.com/microsoft/vcpkg/blob/master/ports/duktape/CMakeLists.txt
+#
+
+cmake_minimum_required(VERSION 3.13)
+
+set(duktape_MAJOR_VERSION 2)
+set(duktape_MINOR_VERSION 7)
+set(duktape_PATCH_VERSION 0)
+set(duktape_VERSION ${duktape_MAJOR_VERSION}.${duktape_MINOR_VERSION}.${duktape_PATCH_VERSION})
+
+option(CMAKE_VERBOSE_MAKEFILE "Create verbose makefile" OFF)
+option(BUILD_SHARED_LIBS "Create duktape as a shared library" OFF)
+
+project(duktape VERSION ${duktape_VERSION})
+
+file(GLOB_RECURSE DUKTAPE_SOURCES "${CMAKE_CURRENT_LIST_DIR}/src/*.c")
+file(GLOB_RECURSE DUKTAPE_HEADERS "${CMAKE_CURRENT_LIST_DIR}/src/*.h")
+
+add_library(duktape ${DUKTAPE_SOURCES} ${DUKTAPE_HEADERS})
+target_include_directories(duktape PRIVATE "${CMAKE_CURRENT_LIST_DIR}/src")
+set_target_properties(duktape PROPERTIES PUBLIC_HEADER "${DUKTAPE_HEADERS}")
+set_target_properties(duktape PROPERTIES VERSION ${duktape_VERSION})
+set_target_properties(duktape PROPERTIES SOVERSION ${duktape_MAJOR_VERSION})
+
+if (BUILD_SHARED_LIBS)
+    target_compile_definitions(duktape PRIVATE -DDUK_F_DLL_BUILD)
+endif ()
+
+install(TARGETS duktape
+        EXPORT duktapeTargets
+        ARCHIVE DESTINATION "lib"
+        LIBRARY DESTINATION "lib"
+        RUNTIME DESTINATION "bin"
+        PUBLIC_HEADER DESTINATION "include"
+        COMPONENT dev
+)
+
+install(EXPORT duktapeTargets
+        FILE duktapeTargets.cmake
+        NAMESPACE duktape::
+        DESTINATION "share/duktape"
+)
+
+export(PACKAGE duktape)
+
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file("${PROJECT_BINARY_DIR}/duktapeConfigVersion.cmake"
+        COMPATIBILITY SameMajorVersion
+)
+
+configure_file(duktapeConfig.cmake.in "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/duktapeConfig.cmake" @ONLY)
+
+install(FILES
+        "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/duktapeConfig.cmake"
+        "${PROJECT_BINARY_DIR}/duktapeConfigVersion.cmake"
+        DESTINATION "share/duktape"
+)

--- a/third-party/duktape/duktapeConfig.cmake.in
+++ b/third-party/duktape/duktapeConfig.cmake.in
@@ -1,0 +1,48 @@
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# Copyright (c) 2024 Alan de Freitas (alandefreitas@gmail.com)
+#
+# Official repository: https://github.com/cppalliance/mrdocs
+#
+#
+
+#
+# This file is derived from the CMakeLists.txt file in the Microsoft vcpkg repository:
+# https://github.com/microsoft/vcpkg/blob/master/ports/duktape/CMakeLists.txt
+#
+
+# - Try to find duktape
+# Once done this will define
+#
+#  DUKTAPE_FOUND - system has Duktape
+#  DUKTAPE_INCLUDE_DIRS - the Duktape include directory
+#  DUKTAPE_LIBRARIES - Link these to use DUKTAPE
+#  DUKTAPE_DEFINITIONS - Compiler switches required for using Duktape
+#
+
+find_package(PkgConfig QUIET)
+pkg_check_modules(PC_DUK QUIET duktape libduktape)
+
+find_path(DUKTAPE_INCLUDE_DIR duktape.h
+        HINTS ${duktape_ROOT}/include ${PC_DUK_INCLUDEDIR} ${PC_DUK_INCLUDE_DIRS}
+        PATH_SUFFIXES duktape)
+
+find_library(DUKTAPE_LIBRARY
+        NAMES duktape libduktape
+        HINTS ${duktape_ROOT}/lib ${duktape_ROOT}/bin ${PC_DUK_LIBDIR} ${PC_DUK_LIBRARY_DIRS})
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(duktape REQUIRED_VARS DUKTAPE_LIBRARY DUKTAPE_INCLUDE_DIR)
+
+if (DUKTAPE_FOUND)
+    set(DUKTAPE_LIBRARIES ${DUKTAPE_LIBRARY})
+    set(DUKTAPE_INCLUDE_DIRS ${DUKTAPE_INCLUDE_DIR})
+endif ()
+
+MARK_AS_ADVANCED(
+        DUKTAPE_INCLUDE_DIR
+        DUKTAPE_LIBRARY
+)


### PR DESCRIPTION
This PR is a continuation of #552 as an intermediary step to fix #547. It updates the CI workflow and the installation instructions so that they do not necessarily depend on VcPkg (although it's still an option) to install dependencies. The motivation is to be able to customize how these dependencies are built to later be able to build MrDocs with one of the strategies listed in #547.