### PR TITLE
ci: use official libxml2 release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,6 @@ jobs:
           TZ: 'Etc/UTC'
         with:
           apt-get: ${{ matrix.install }} git build-essential python3 curl openjdk-11-jdk ninja-build pkg-config libncurses-dev
-          vcpkg: libxml2[tools]
           cc: ${{ steps.setup-cpp.outputs.cc || matrix.cc }}
           ccflags: ${{ matrix.ccflags }}
           cxx: ${{ steps.setup-cpp.outputs.cxx || matrix.cxx }}
@@ -146,6 +145,32 @@ jobs:
               echo "$duktape_root"
           fi
           echo -E "duktape-root=$duktape_root" >> $GITHUB_OUTPUT
+
+      - name: Install Libxml2
+        id: libxml2-install
+        shell: bash
+        run: |
+          set -x
+          cd ..
+          mkdir -p third-party
+          cd third-party
+          git config --global init.defaultBranch master
+          git config --global advice.detachedHead false
+          git clone https://github.com/GNOME/libxml2 --branch v2.12.6 --depth 1
+          cd libxml2
+          
+          cmake -S . -B ./build -DCMAKE_BUILD_TYPE=Release -DLIBXML2_WITH_PROGRAMS=ON -DLIBXML2_WITH_FTP=OFF -DLIBXML2_WITH_HTTP=OFF -DLIBXML2_WITH_ICONV=OFF -DLIBXML2_WITH_LEGACY=OFF -DLIBXML2_WITH_LZMA=OFF -DLIBXML2_WITH_ZLIB=OFF -DLIBXML2_WITH_ICU=OFF -DLIBXML2_WITH_TESTS=OFF -DLIBXML2_WITH_HTML=ON -DLIBXML2_WITH_C14N=ON -DLIBXML2_WITH_CATALOG=ON -DLIBXML2_WITH_DEBUG=ON -DLIBXML2_WITH_ISO8859X=ON -DLIBXML2_WITH_MEM_DEBUG=OFF -DLIBXML2_WITH_MODULES=ON -DLIBXML2_WITH_OUTPUT=ON -DLIBXML2_WITH_PATTERN=ON -DLIBXML2_WITH_PUSH=ON -DLIBXML2_WITH_PYTHON=OFF -DLIBXML2_WITH_READER=ON -DLIBXML2_WITH_REGEXPS=ON -DLIBXML2_WITH_SAX1=ON -DLIBXML2_WITH_SCHEMAS=ON -DLIBXML2_WITH_SCHEMATRON=ON -DLIBXML2_WITH_THREADS=ON -DLIBXML2_WITH_THREAD_ALLOC=OFF -DLIBXML2_WITH_TREE=ON -DLIBXML2_WITH_VALID=ON -DLIBXML2_WITH_WRITER=ON -DLIBXML2_WITH_XINCLUDE=ON -DLIBXML2_WITH_XPATH=ON -DLIBXML2_WITH_XPTR=ON -DCMAKE_CXX_COMPILER=${{ steps.setup-cpp.outputs.cxx || steps.parameters.outputs.clang-bin }} -DCMAKE_C_COMPILER=${{ steps.setup-cpp.outputs.cc || steps.parameters.outputs.clang-bin }}
+          N_CORES=$(nproc 2>/dev/null || echo 1)
+          cmake --build ./build --config ${{ matrix.build-type }} --parallel $N_CORES 
+          cmake --install ./build --prefix ./install
+          
+          libxml2_root=$(pwd)/install
+          if [[ ${{ runner.os }} == 'Windows' ]]; then
+              libxml2_root=$(echo "$libxml2_root" | sed 's/\\/\//g')
+              libxml2_root=$(echo $libxml2_root | sed 's|^/d/|D:/|')
+              echo "$libxml2_root"
+          fi
+          echo -E "libxml2-root=$libxml2_root" >> $GITHUB_OUTPUT
 
       - name: LLVM Parameters
         id: llvm-parameters
@@ -229,6 +254,8 @@ jobs:
             -D duktape_ROOT=${{ steps.duktape-install.outputs.duktape-root }}
             -D Duktape_ROOT=${{ steps.duktape-install.outputs.duktape-root }}
             -D fmt_ROOT=${{ steps.fmt-install.outputs.fmt-root }}
+            -D libxml2_ROOT=${{ steps.libxml2-install.outputs.libxml2-root }}
+            -D LibXml2_ROOT=${{ steps.libxml2-install.outputs.libxml2-root }}
           export-compile-commands: true
           run-tests: true
           install: true

--- a/docs/modules/ROOT/pages/install.adoc
+++ b/docs/modules/ROOT/pages/install.adoc
@@ -56,7 +56,7 @@ cd ..
 ----
 
 <.> Shallow clones the fmt repository.
-<.> Configure the fmt library with CMake, exclusing the documentation and tests.
+<.> Configure the fmt library with CMake, excluding the documentation and tests.
 <.> Builds the fmt library in the `build` directory.
 <.> Installs the fmt library in the `install` directory.
 
@@ -80,7 +80,7 @@ Windows PowerShell::
 git clone https://github.com/microsoft/vcpkg.git -b master <.>
 cd vcpkg
 bootstrap-vcpkg.bat <.>
-vcpkg.exe fmt --triplet x64-windows <.>
+vcpkg.exe install fmt --triplet x64-windows <.>
 ----
 
 <.> Clones the Vcpkg repository.
@@ -96,7 +96,7 @@ Unix Variants::
 git clone https://github.com/microsoft/vcpkg.git -b master <.>
 cd vcpkg
 ./bootstrap-vcpkg.sh <.>
-./vcpkg fmt <.>
+./vcpkg install fmt <.>
 ----
 
 <.> Clones the Vcpkg repository.
@@ -217,7 +217,7 @@ Windows PowerShell::
 [source,bash]
 ----
 cd vcpkg
-vcpkg.exe duktape --triplet x64-windows <.>
+vcpkg.exe install duktape --triplet x64-windows <.>
 ----
 
 <.> Installs the `duktape` library.
@@ -229,10 +229,64 @@ Unix Variants::
 [source,bash]
 ----
 cd vcpkg
-./vcpkg duktape <.>
+./vcpkg install duktape <.>
 ----
 
 <.> Installs the `duktape` library.
+--
+====
+
+NOTE: These examples assume VcPkg is already installed in the `third-party/vcpkg` directory (see the <<install-fmt>> section).
+
+=== Libxml2
+
+MrDocs uses `libxml2` tools for tests.
+Only developers need to install this dependency.
+Users can skip this step.
+
+From the `third-party` directory, you can clone the `libxml2` repository and install it with the following commands:
+
+[source,bash]
+----
+git clone https://github.com/GNOME/libxml2 --branch v2.12.6 --depth 1 <.>
+cd libxml2
+cmake -S . -B ./build -DCMAKE_BUILD_TYPE=Release -DLIBXML2_WITH_PROGRAMS=ON -DLIBXML2_WITH_FTP=OFF -DLIBXML2_WITH_HTTP=OFF -DLIBXML2_WITH_ICONV=OFF -DLIBXML2_WITH_LEGACY=OFF -DLIBXML2_WITH_LZMA=OFF -DLIBXML2_WITH_ZLIB=OFF -DLIBXML2_WITH_ICU=OFF -DLIBXML2_WITH_TESTS=OFF -DLIBXML2_WITH_HTML=ON -DLIBXML2_WITH_C14N=ON -DLIBXML2_WITH_CATALOG=ON -DLIBXML2_WITH_DEBUG=ON -DLIBXML2_WITH_ISO8859X=ON -DLIBXML2_WITH_MEM_DEBUG=OFF -DLIBXML2_WITH_MODULES=ON -DLIBXML2_WITH_OUTPUT=ON -DLIBXML2_WITH_PATTERN=ON -DLIBXML2_WITH_PUSH=ON -DLIBXML2_WITH_PYTHON=OFF -DLIBXML2_WITH_READER=ON -DLIBXML2_WITH_REGEXPS=ON -DLIBXML2_WITH_SAX1=ON -DLIBXML2_WITH_SCHEMAS=ON -DLIBXML2_WITH_SCHEMATRON=ON -DLIBXML2_WITH_THREADS=ON -DLIBXML2_WITH_THREAD_ALLOC=OFF -DLIBXML2_WITH_TREE=ON -DLIBXML2_WITH_VALID=ON -DLIBXML2_WITH_WRITER=ON -DLIBXML2_WITH_XINCLUDE=ON -DLIBXML2_WITH_XPATH=ON -DLIBXML2_WITH_XPTR=ON <.>
+cmake --build ./build --config Release <.>
+cmake --install ./build --prefix ./install <.>
+cd ..
+----
+
+<.> Shallow clones the libxml2 repository.
+<.> Configure the libxml2 with CMake, excluding the documentation, tests, and unwanted dependencies.
+<.> Builds libxml2 in the `build` directory.
+<.> Installs libxml2 in the `install` directory.
+
+If you prefer using Vcpkg to install dependencies, you can install `libxml2` with the following commands from the `third-party` directory:
+
+[tabs]
+====
+Windows PowerShell::
++
+--
+[source,bash]
+----
+cd vcpkg
+vcpkg.exe install libxml2[tools] --triplet x64-windows <.>
+----
+
+<.> Installs `libxml2`.
+--
+
+Unix Variants::
++
+--
+[source,bash]
+----
+cd vcpkg
+./vcpkg install libxml2[tools] <.>
+----
+
+<.> Installs `libxml2`.
 --
 ====
 
@@ -332,33 +386,6 @@ Return from `./third-party/llvm-project/llvm` to the parent directory to build a
 ----
 cd ../../..
 ----
-
-=== Libxml2
-
-Developers should also install the `libxml2` tools to parse XML files.
-This tool is used in tests.
-You can install the libxml2 tools with Vcpkg:
-
-[tabs]
-====
-Windows PowerShell::
-+
---
-[source,bash]
-----
-vcpkg.exe libxml2[tools] --triplet x64-windows
-----
---
-
-Unix Variants::
-+
---
-[source,bash]
-----
-./vcpkg libxml2[tools]
-----
---
-====
 
 === MrDocs
 


### PR DESCRIPTION
This extends the same logic of other dependencies and avoids bugs in the vcpkg port.