### PR TITLE
CI minor issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -341,6 +341,7 @@ jobs:
           # Add SSH key
           mkdir -p /home/runner/.ssh
           ssh-keyscan dev-websites.cpp.al >> /home/runner/.ssh/known_hosts
+          chmod 600 /home/runner/.ssh/known_hosts
           echo "${{ secrets.DEV_WEBSITES_SSH_KEY }}" > /home/runner/.ssh/github_actions
           chmod 600 /home/runner/.ssh/github_actions
           ssh-agent -a $SSH_AUTH_SOCK > /dev/null
@@ -452,8 +453,8 @@ jobs:
           # Add SSH key
           set -x
           mkdir -p /home/runner/.ssh
-          chmod 600 /home/runner/.ssh/known_hosts
           ssh-keyscan dev-websites.cpp.al >> /home/runner/.ssh/known_hosts
+          chmod 600 /home/runner/.ssh/known_hosts
           echo "${{ secrets.DEV_WEBSITES_SSH_KEY }}" > /home/runner/.ssh/github_actions
           chmod 600 /home/runner/.ssh/github_actions
           ssh-agent -a $SSH_AUTH_SOCK > /dev/null

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,11 +103,11 @@ string(REGEX REPLACE " /W[0-4]" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
 find_package(fmt REQUIRED CONFIG)
 
 # Duktape
-find_package(duktape CONFIG)
+find_package(Duktape CONFIG)
 if (NOT DUKTAPE_FOUND)
     # Duktape doesn't nativelly support CMake.
     # Some config script patches use the capitalized version.
-    find_package(Duktape REQUIRED CONFIG)
+    find_package(duktape REQUIRED CONFIG)
 endif()
 
 unset(CMAKE_FOLDER)


### PR DESCRIPTION
This PR updates known_hosts permissions to 600 to avoid errors uploading to the website. CMakeLists.txt gives the capitalized version of the duktape package higher precedence to avoid unnecessary warnings locally and in CI.