### PR TITLE
CI: fix demos and releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -450,15 +450,7 @@ jobs:
           for variant in single multi; do
             for generator in "${generators[@]}"; do
               [[ $variant = multi ]] && multipage="true" || multipage="false"
-              # Override with cmd line option
-              mrdocs \
-                --config="$(pwd)/boost/libs/url/doc/mrdocs.yml" \
-                "../CMakeLists.txt" \ 
-                --output="$(pwd)/demos/boost-url/$variant/$generator" \
-                --multipage=$multipage \
-                --generate="$$generator"
-                
-              # Print number of files (recursive) in the output directory
+              mrdocs --config="$(pwd)/boost/libs/url/doc/mrdocs.yml" "../CMakeLists.txt" --output="$(pwd)/demos/boost-url/$variant/$generator" --multipage=$multipage --generate="$generator"
               echo "Number of files in demos/boost-url/$variant/$format: $(find demos/boost-url/$variant/$format -type f | wc -l)"
             done
             asciidoctor -d book -R "$(pwd)/demos/boost-url/$variant/adoc" -D "$(pwd)/demos/boost-url/$variant/adoc-asciidoc" "$(pwd)/demos/boost-url/$variant/adoc/**/*.adoc"
@@ -613,7 +605,7 @@ jobs:
       - name: Check info nodes
         run: |
           set -x
-          chmod +x .github/check_info_nodes.sh
+          chmod +x .github/check_info_nodes_support.sh
           .github/check_info_nodes_support.sh
 
       - name: Create GitHub Package Release

--- a/src/test/TestRunner.cpp
+++ b/src/test/TestRunner.cpp
@@ -66,6 +66,8 @@ handleFile(
     llvm::StringRef filePath,
     std::shared_ptr<ConfigImpl const> config)
 {
+    fmt::println("handleFile: {}", filePath);
+
     namespace fs = llvm::sys::fs;
     namespace path = llvm::sys::path;
 
@@ -271,6 +273,8 @@ handleDir(
     std::string dirPath,
     std::shared_ptr<ConfigImpl const> config)
 {
+    fmt::println("handleDir: {}", dirPath);
+
     namespace fs = llvm::sys::fs;
     namespace path = llvm::sys::path;
 

--- a/src/tool/ToolArgs.cpp
+++ b/src/tool/ToolArgs.cpp
@@ -255,12 +255,13 @@ apply(
         auto absPath = files::makeAbsolute(cmdLineInput, s.configDir);
         if (files::isDirectory(cmdLineInput))
         {
-            s.sourceRoot = files::normalizeDir(files::makeAbsolute(cmdLineInput, s.configDir));
+            s.sourceRoot = cmdLineInput;
             continue;
         }
         // Input category is unknown
         report::warn("Ignoring unknown input path: {}", cmdLineInput);
     }
+    s.sourceRoot = files::normalizeDir(files::makeAbsolute(s.sourceRoot, s.configDir));
 
     // Set compilation database from source root
     if (s.compilationDatabase.empty() && !s.sourceRoot.empty())

--- a/src/tool/ToolArgs.cpp
+++ b/src/tool/ToolArgs.cpp
@@ -55,6 +55,10 @@ EXAMPLES:
 , addons(llvm::cl::cat(generatorCat))
 , multipage(llvm::cl::init(true), llvm::cl::cat(generatorCat))
 , baseURL(llvm::cl::cat(generatorCat))
+, verbose(llvm::cl::cat(extraCat))
+, report(llvm::cl::init(1), llvm::cl::cat(extraCat))
+, ignoreMapErrors(llvm::cl::cat(extraCat))
+, ignoreFailures(llvm::cl::cat(extraCat))
 , referencedDeclarations(llvm::cl::init("dependency"), llvm::cl::cat(filtersCat))
 , anonymousNamespaces(llvm::cl::init("always"), llvm::cl::cat(filtersCat))
 , inaccessibleMembers(llvm::cl::init("always"), llvm::cl::cat(filtersCat))
@@ -63,10 +67,6 @@ EXAMPLES:
 , filters(filtersCat)
 , seeBelow(llvm::cl::cat(filtersCat))
 , implementationDefined(llvm::cl::cat(filtersCat))
-, verbose(llvm::cl::cat(extraCat))
-, report(llvm::cl::init(1), llvm::cl::cat(extraCat))
-, ignoreMapErrors(llvm::cl::cat(extraCat))
-, ignoreFailures(llvm::cl::cat(extraCat))
 {}
 
 ToolArgs::

--- a/src/tool/ToolArgs.hpp
+++ b/src/tool/ToolArgs.hpp
@@ -46,9 +46,6 @@ public:
 
     // ------------------------------------------------
     // Common options
-    /// Path to the Addons directory
-    llvm::cl::opt<std::string> addons;
-
     /// Path to the source root directory
     llvm::cl::opt<std::string> sourceRoot;
 
@@ -67,6 +64,9 @@ public:
 
     /// Documentation generator. Supported generators are: adoc, html, xml
     llvm::cl::opt<std::string> generate;
+
+    /// Path to the Addons directory
+    llvm::cl::opt<std::string> addons;
 
     /// True if output should consist of multiple files)
     llvm::cl::opt<bool> multipage;


### PR DESCRIPTION
The runner image has been updated, and it's now possible to fix the LLVM build step and test segfaults that previously blocked CI. So, this PR includes some minor changes in CI related to errors in generating demos and releases. It also fixes GCC/Clang warnings in passing.