### PR TITLE
fix: infinite recursion when identifying SFINAE types

### DIFF
--- a/src/lib/AST/ASTVisitor.cpp
+++ b/src/lib/AST/ASTVisitor.cpp
@@ -1716,6 +1716,11 @@ public:
                             return true;
                         continue;
                     }
+                    // if the class inherits from itself, we can't determine whether
+                    // it's a SFINAE type
+                    if(declaresSameEntity(TD, sfinae_info->Template))
+                        return true;
+
                     auto sfinae_result = isSFINAETemplate(
                         sfinae_info->Template, Member);
                     if(! sfinae_result)


### PR DESCRIPTION
Fixes #665. Note that this fix isn't perfect as it does not handle cases where the recursion period is greater than one.