### PR TITLE
fix: missing template parameters in asciidoc templates

### DIFF
--- a/share/mrdocs/addons/generator/asciidoc/partials/symbols/function.adoc.hbs
+++ b/share/mrdocs/addons/generator/asciidoc/partials/symbols/function.adoc.hbs
@@ -40,6 +40,20 @@
 
 {{/if}}
 
+{{#if symbol.doc.tparams}}
+=={{#unless is_multipage}}={{/unless}} Template Parameters
+
+|===
+| Name | Description
+
+{{#each symbol.doc.tparams}}
+| *{{name}}*
+| {{description}}
+{{/each}}
+|===
+
+{{/if}}
+
 {{#if symbol.doc.params}}
 =={{#unless is_multipage}}={{/unless}} Parameters
 

--- a/share/mrdocs/addons/generator/asciidoc/partials/symbols/record.adoc.hbs
+++ b/share/mrdocs/addons/generator/asciidoc/partials/symbols/record.adoc.hbs
@@ -25,6 +25,20 @@
 
 {{/if}}
 
+{{#if symbol.doc.tparams}}
+=={{#unless is_multipage}}={{/unless}} Template Parameters
+
+|===
+| Name | Description
+
+{{#each symbol.doc.tparams}}
+| *{{name}}*
+| {{description}}
+{{/each}}
+|===
+
+{{/if}}
+
 {{#if symbol.doc.see}}
 =={{#unless is_multipage}}={{/unless}} See Also
 


### PR DESCRIPTION
Fixes https://github.com/cppalliance/mrdocs/issues/674