### PR TITLE
feat: navigation button links to enclosing namespace

### DIFF
--- a/share/mrdocs/addons/generator/adoc/layouts/wrapper.adoc.hbs
+++ b/share/mrdocs/addons/generator/adoc/layouts/wrapper.adoc.hbs
@@ -9,7 +9,7 @@
 
     Breadcrumbs are included in the symbol template as an alternative.
 }}
-= {{> symbol/qualified-name symbol }}
+= {{> symbol/enclosing-namespace symbol }}{{> symbol/qualified-name symbol }}
 {{!
     Antora does not support relative links to pages in
     parent directories. Therefore, unlike in HTML templates,

--- a/share/mrdocs/addons/generator/common/partials/symbol/enclosing-namespace.hbs
+++ b/share/mrdocs/addons/generator/common/partials/symbol/enclosing-namespace.hbs
@@ -1,0 +1,14 @@
+{{!--
+    Renders a link to the enclosing namespace with a custom symbol (⬆).
+    If no enclosing namespace exists, nothing is rendered.
+
+    Expected Context: {Symbol Object}
+
+    Example:
+        {{> symbol/enclosing-namespace symbol }}
+
+    See: https://mrdocs.com/docs/mrdocs/develop/generators.html#dom_reference
+--}}
+{{~#if (and parent parent.name)~}}
+    xref:{{{remove_prefix parent.url "/"}}}[⬆]
+{{~/if~}}


### PR DESCRIPTION
Fixes #469

It took me quite a while to investigate where the SVG "house" icon is being generated.


<img width="290" alt="image" src="https://github.com/user-attachments/assets/4b705da9-b895-45ac-9ba1-d62f525c9850" />

I explored various parts of the codebase and toolchain but couldn't locate it. As of now, I still don’t know if this behavior can be modified. Based on my research so far, it doesn't seem to be controlled by MrDocs but rather by subsequent tools in the toolchain, such as Antora.

I came up with this change—not ideal, but it’s a starting point to evaluate if it’s acceptable. If it’s not, any pointers on how to control the house icon generation would be much appreciated. As I mentioned, it doesn’t seem to be within the MrDocs repository.