### PR TITLE
replicate doxygen warning options

### DIFF
--- a/docs/mrdocs.schema.json
+++ b/docs/mrdocs.schema.json
@@ -439,6 +439,16 @@
       ],
       "title": "Verbose output",
       "type": "boolean"
+    },
+    "warnings": {
+      "default": true,
+      "description": "When set to `true`, MrDocs outputs warning messages during the generation of the documentation. It is usually recommended to enable warnings while writing the documentation.",
+      "enum": [
+        true,
+        false
+      ],
+      "title": "Enable warning messages",
+      "type": "boolean"
     }
   },
   "required": [],

--- a/docs/mrdocs.schema.json
+++ b/docs/mrdocs.schema.json
@@ -93,7 +93,7 @@
     },
     "extract-all": {
       "default": true,
-      "description": "When set to `true`, MrDocs extracts all symbols from the source code, even if no documentation is provided. When set to `false`, it's still recommendable to provide file and symbol filters so that only the desired symbols are traversed by MrDocs.",
+      "description": "When set to `true`, MrDocs extracts all symbols from the source code, even if no documentation is provided. MrDocs can only identify whether a symbol is ultimated documented after extracting information from all translation units. For this reason, when this option is set to `false`, it's still recommendable to provide file and symbol filters so that only the desired symbols are traversed and stored by MrDocs.",
       "enum": [
         true,
         false
@@ -448,6 +448,16 @@
         false
       ],
       "title": "Verbose output",
+      "type": "boolean"
+    },
+    "warn-if-undocumented": {
+      "default": true,
+      "description": "When set to `true`, MrDocs outputs a warning message if a symbol that passes all filters is not documented. This option is only effective when `extract-all` is set to `false`.",
+      "enum": [
+        true,
+        false
+      ],
+      "title": "Warn if symbols are not documented",
       "type": "boolean"
     },
     "warnings": {

--- a/docs/mrdocs.schema.json
+++ b/docs/mrdocs.schema.json
@@ -450,6 +450,16 @@
       "title": "Verbose output",
       "type": "boolean"
     },
+    "warn-if-doc-error": {
+      "default": true,
+      "description": "When set to `true`, MrDocs outputs a warning message if the documentation of a symbol has errors such as duplicate parameters and parameters that don't exist.",
+      "enum": [
+        true,
+        false
+      ],
+      "title": "Warn if documentation has errors",
+      "type": "boolean"
+    },
     "warn-if-undocumented": {
       "default": true,
       "description": "When set to `true`, MrDocs outputs a warning message if a symbol that passes all filters is not documented. This option is only effective when `extract-all` is set to `false`.",

--- a/docs/mrdocs.schema.json
+++ b/docs/mrdocs.schema.json
@@ -460,6 +460,16 @@
       "title": "Warn if documentation has errors",
       "type": "boolean"
     },
+    "warn-if-undoc-enum-val": {
+      "default": true,
+      "description": "When set to `true`, MrDocs outputs a warning message if an enum value is not documented.",
+      "enum": [
+        true,
+        false
+      ],
+      "title": "Warn if enum values are not documented",
+      "type": "boolean"
+    },
     "warn-if-undocumented": {
       "default": true,
       "description": "When set to `true`, MrDocs outputs a warning message if a symbol that passes all filters is not documented.",

--- a/docs/mrdocs.schema.json
+++ b/docs/mrdocs.schema.json
@@ -462,12 +462,22 @@
     },
     "warn-if-undocumented": {
       "default": true,
-      "description": "When set to `true`, MrDocs outputs a warning message if a symbol that passes all filters is not documented. This option is only effective when `extract-all` is set to `false`.",
+      "description": "When set to `true`, MrDocs outputs a warning message if a symbol that passes all filters is not documented.",
       "enum": [
         true,
         false
       ],
       "title": "Warn if symbols are not documented",
+      "type": "boolean"
+    },
+    "warn-no-paramdoc": {
+      "default": true,
+      "description": "When set to `true`, MrDocs outputs a warning message if a named function parameter is not documented.",
+      "enum": [
+        true,
+        false
+      ],
+      "title": "Warn if parameters are not documented",
       "type": "boolean"
     },
     "warnings": {

--- a/docs/mrdocs.schema.json
+++ b/docs/mrdocs.schema.json
@@ -450,6 +450,16 @@
       "title": "Verbose output",
       "type": "boolean"
     },
+    "warn-as-error": {
+      "default": false,
+      "description": "When set to `true`, MrDocs treats warnings as errors and stops the generation of the documentation.",
+      "enum": [
+        true,
+        false
+      ],
+      "title": "Treat warnings as errors",
+      "type": "boolean"
+    },
     "warn-broken-ref": {
       "default": true,
       "description": "When set to `true`, MrDocs outputs a warning message if a reference in the documentation is broken.",

--- a/docs/mrdocs.schema.json
+++ b/docs/mrdocs.schema.json
@@ -450,6 +450,16 @@
       "title": "Verbose output",
       "type": "boolean"
     },
+    "warn-broken-ref": {
+      "default": true,
+      "description": "When set to `true`, MrDocs outputs a warning message if a reference in the documentation is broken.",
+      "enum": [
+        true,
+        false
+      ],
+      "title": "Warn if a documentation reference is broken",
+      "type": "boolean"
+    },
     "warn-if-doc-error": {
       "default": true,
       "description": "When set to `true`, MrDocs outputs a warning message if the documentation of a symbol has errors such as duplicate parameters and parameters that don't exist.",

--- a/docs/mrdocs.schema.json
+++ b/docs/mrdocs.schema.json
@@ -91,6 +91,16 @@
       "title": "Symbol patterns to exclude",
       "type": "array"
     },
+    "extract-all": {
+      "default": true,
+      "description": "When set to `true`, MrDocs extracts all symbols from the source code, even if no documentation is provided. When set to `false`, it's still recommendable to provide file and symbol filters so that only the desired symbols are traversed by MrDocs.",
+      "enum": [
+        true,
+        false
+      ],
+      "title": "Extract all symbols",
+      "type": "boolean"
+    },
     "file-patterns": {
       "default": [
         "*.hpp",

--- a/src/lib/AST/ASTVisitor.cpp
+++ b/src/lib/AST/ASTVisitor.cpp
@@ -3334,7 +3334,8 @@ checkUndocumented(
     {
         if (config_->warnIfUndocumented)
         {
-            undocumented_.erase({id, extractName(D)});
+            auto const it = undocumented_.find(id);
+            undocumented_.erase(it);
         }
         return {};
     }

--- a/src/lib/AST/ASTVisitorConsumer.cpp
+++ b/src/lib/AST/ASTVisitorConsumer.cpp
@@ -15,8 +15,7 @@
 #include "lib/AST/ASTVisitor.hpp"
 #include "lib/Support/Path.hpp"
 
-namespace clang {
-namespace mrdocs {
+namespace clang::mrdocs {
 
 void
 ASTVisitorConsumer::
@@ -31,8 +30,7 @@ HandleTranslationUnit(ASTContext& Context)
         Context,
         *sema_);
     visitor.build();
-    ex_.report(std::move(visitor.results()), std::move(diags));
+    ex_.report(std::move(visitor.results()), std::move(diags), std::move(visitor.undocumented()));
 }
 
-} // mrdocs
-} // clang
+} // clang::mrdocs

--- a/src/lib/Lib/ConfigOptions.json
+++ b/src/lib/Lib/ConfigOptions.json
@@ -499,6 +499,13 @@
         "details": "When set to `true`, MrDocs outputs a warning message if a named function parameter is not documented.",
         "type": "bool",
         "default": true
+      },
+      {
+        "name": "warn-if-undoc-enum-val",
+        "brief": "Warn if enum values are not documented",
+        "details": "When set to `true`, MrDocs outputs a warning message if an enum value is not documented.",
+        "type": "bool",
+        "default": true
       }
     ]
   },

--- a/src/lib/Lib/ConfigOptions.json
+++ b/src/lib/Lib/ConfigOptions.json
@@ -160,21 +160,42 @@
     ]
   },
   {
+    "category": "Comment Parsing",
+    "brief": "Options to control how comments are parsed",
+    "details": "MrDocs extracts metadata from the comments in the source code. The following options control how comments are parsed.",
+    "options": [
+      {
+        "name": "auto-brief",
+        "brief": "Use the first line of the comment as the brief",
+        "details": "When set to `true`, MrDocs uses the first line (until the first dot, question mark, or exclamation mark) of the comment as the brief of the symbol. When set to `false`, a explicit @brief command is required.",
+        "type": "bool",
+        "default": true
+      }
+    ]
+  },
+  {
     "category": "Metadata Extraction",
     "brief": "Metadata and C++ semantic constructs to extract",
     "details": "MrDocs extracts metadata and C++ semantic constructs from the source code to create the documentation. Semantic constructs are patterns not directly represented in the source code AST but can be inferred from the corpus, such as SFINAE. The following options control the extraction of metadata and C++ semantic constructs.",
     "options": [
       {
-        "name": "sfinae",
-        "brief": "Detect and reduce SFINAE expressions",
-        "details": "When set to true, MrDocs detects SFINAE expressions in the source code and extracts them as part of the documentation. Expressions such as `std::enable_if<...>` are detected, removed, and documented as a requirement. MrDocs uses an algorithm that extracts SFINAE infomation from types by identifying inspecting the primary template and specializations to detect the result type and the controlling expressions in a specialization.",
+        "name": "extract-all",
+        "brief": "Extract all symbols",
+        "details": "When set to `true`, MrDocs extracts all symbols from the source code, even if no documentation is provided. When set to `false`, it's still recommendable to provide file and symbol filters so that only the desired symbols are traversed by MrDocs.",
         "type": "bool",
         "default": true
       },
       {
-        "name": "overloads",
-        "brief": "Detect and group function overloads",
-        "details": "When set to `true`, MrDocs detects function overloads and groups them as a single symbol type.",
+        "name": "private-members",
+        "brief": "Extraction policy for private class members",
+        "details": "Determine whether private class members should be extracted",
+        "type": "bool",
+        "default": false
+      },
+      {
+        "name": "private-bases",
+        "brief": "Extraction policy for private base classes",
+        "details": "Determine whether private base classes should be extracted",
         "type": "bool",
         "default": true
       },
@@ -190,20 +211,6 @@
           "copy-all"
         ],
         "default": "copy-dependencies"
-      },
-      {
-        "name": "private-members",
-        "brief": "Extraction policy for private class members",
-        "details": "Determine whether private class members should be extracted",
-        "type": "bool",
-        "default": false
-      },
-      {
-        "name": "private-bases",
-        "brief": "Extraction policy for private base classes",
-        "details": "Determine whether private base classes should be extracted",
-        "type": "bool",
-        "default": true
       },
       {
         "name": "anonymous-namespaces",
@@ -253,11 +260,25 @@
         "details": "When set to `true`, relational operators are sorted last in the list of members of a record or namespace.",
         "type": "bool",
         "default": true
+      }
+    ]
+  },
+  {
+    "category": "Semantic Constructs",
+    "brief": "C++ semantic constructs to extract",
+    "details": "Semantic constructs are patterns not directly represented in the source code AST but can be inferred from the corpus, such as SFINAE.",
+    "options": [
+      {
+        "name": "sfinae",
+        "brief": "Detect and reduce SFINAE expressions",
+        "details": "When set to true, MrDocs detects SFINAE expressions in the source code and extracts them as part of the documentation. Expressions such as `std::enable_if<...>` are detected, removed, and documented as a requirement. MrDocs uses an algorithm that extracts SFINAE infomation from types by identifying inspecting the primary template and specializations to detect the result type and the controlling expressions in a specialization.",
+        "type": "bool",
+        "default": true
       },
       {
-        "name": "auto-brief",
-        "brief": "Use the first line of the comment as the brief",
-        "details": "When set to `true`, MrDocs uses the first line (until the first dot, question mark, or exclamation mark) of the comment as the brief of the symbol. When set to `false`, a explicit @brief command is required.",
+        "name": "overloads",
+        "brief": "Detect and group function overloads",
+        "details": "When set to `true`, MrDocs detects function overloads and groups them as a single symbol type.",
         "type": "bool",
         "default": true
       }

--- a/src/lib/Lib/ConfigOptions.json
+++ b/src/lib/Lib/ConfigOptions.json
@@ -416,18 +416,9 @@
     ]
   },
   {
-    "category": "Miscellaneous",
-    "brief": "Miscellaneous options",
+    "category": "Warnings",
+    "brief": "Warnings and progress messages",
     "options": [
-      {
-        "name": "concurrency",
-        "command-line-only": true,
-        "brief": "Number of threads to use",
-        "details": "The desired level of concurrency: 0 for hardware-suggested.",
-        "type": "unsigned",
-        "default": 0,
-        "min-value": 0
-      },
       {
         "name": "verbose",
         "brief": "Verbose output",
@@ -459,6 +450,28 @@
           "fatal"
         ],
         "default": "info"
+      },
+      {
+        "name": "warnings",
+        "brief": "Enable warning messages",
+        "details": "When set to `true`, MrDocs outputs warning messages during the generation of the documentation. It is usually recommended to enable warnings while writing the documentation.",
+        "type": "bool",
+        "default": true
+      }
+    ]
+  },
+  {
+    "category": "Miscellaneous",
+    "brief": "Miscellaneous options",
+    "options": [
+      {
+        "name": "concurrency",
+        "command-line-only": true,
+        "brief": "Number of threads to use",
+        "details": "The desired level of concurrency: 0 for hardware-suggested.",
+        "type": "unsigned",
+        "default": 0,
+        "min-value": 0
       },
       {
         "name": "ignore-map-errors",

--- a/src/lib/Lib/ConfigOptions.json
+++ b/src/lib/Lib/ConfigOptions.json
@@ -513,6 +513,13 @@
         "details": "When set to `true`, MrDocs outputs a warning message if a reference in the documentation is broken.",
         "type": "bool",
         "default": true
+      },
+      {
+        "name": "warn-as-error",
+        "brief": "Treat warnings as errors",
+        "details": "When set to `true`, MrDocs treats warnings as errors and stops the generation of the documentation.",
+        "type": "bool",
+        "default": false
       }
     ]
   },

--- a/src/lib/Lib/ConfigOptions.json
+++ b/src/lib/Lib/ConfigOptions.json
@@ -181,7 +181,7 @@
       {
         "name": "extract-all",
         "brief": "Extract all symbols",
-        "details": "When set to `true`, MrDocs extracts all symbols from the source code, even if no documentation is provided. When set to `false`, it's still recommendable to provide file and symbol filters so that only the desired symbols are traversed by MrDocs.",
+        "details": "When set to `true`, MrDocs extracts all symbols from the source code, even if no documentation is provided. MrDocs can only identify whether a symbol is ultimated documented after extracting information from all translation units. For this reason, when this option is set to `false`, it's still recommendable to provide file and symbol filters so that only the desired symbols are traversed and stored by MrDocs.",
         "type": "bool",
         "default": true
       },
@@ -476,6 +476,13 @@
         "name": "warnings",
         "brief": "Enable warning messages",
         "details": "When set to `true`, MrDocs outputs warning messages during the generation of the documentation. It is usually recommended to enable warnings while writing the documentation.",
+        "type": "bool",
+        "default": true
+      },
+      {
+        "name": "warn-if-undocumented",
+        "brief": "Warn if symbols are not documented",
+        "details": "When set to `true`, MrDocs outputs a warning message if a symbol that passes all filters is not documented. This option is only effective when `extract-all` is set to `false`.",
         "type": "bool",
         "default": true
       }

--- a/src/lib/Lib/ConfigOptions.json
+++ b/src/lib/Lib/ConfigOptions.json
@@ -506,6 +506,13 @@
         "details": "When set to `true`, MrDocs outputs a warning message if an enum value is not documented.",
         "type": "bool",
         "default": true
+      },
+      {
+        "name": "warn-broken-ref",
+        "brief": "Warn if a documentation reference is broken",
+        "details": "When set to `true`, MrDocs outputs a warning message if a reference in the documentation is broken.",
+        "type": "bool",
+        "default": true
       }
     ]
   },

--- a/src/lib/Lib/ConfigOptions.json
+++ b/src/lib/Lib/ConfigOptions.json
@@ -485,6 +485,13 @@
         "details": "When set to `true`, MrDocs outputs a warning message if a symbol that passes all filters is not documented. This option is only effective when `extract-all` is set to `false`.",
         "type": "bool",
         "default": true
+      },
+      {
+        "name": "warn-if-doc-error",
+        "brief": "Warn if documentation has errors",
+        "details": "When set to `true`, MrDocs outputs a warning message if the documentation of a symbol has errors such as duplicate parameters and parameters that don't exist.",
+        "type": "bool",
+        "default": true
       }
     ]
   },

--- a/src/lib/Lib/ConfigOptions.json
+++ b/src/lib/Lib/ConfigOptions.json
@@ -482,7 +482,7 @@
       {
         "name": "warn-if-undocumented",
         "brief": "Warn if symbols are not documented",
-        "details": "When set to `true`, MrDocs outputs a warning message if a symbol that passes all filters is not documented. This option is only effective when `extract-all` is set to `false`.",
+        "details": "When set to `true`, MrDocs outputs a warning message if a symbol that passes all filters is not documented.",
         "type": "bool",
         "default": true
       },
@@ -490,6 +490,13 @@
         "name": "warn-if-doc-error",
         "brief": "Warn if documentation has errors",
         "details": "When set to `true`, MrDocs outputs a warning message if the documentation of a symbol has errors such as duplicate parameters and parameters that don't exist.",
+        "type": "bool",
+        "default": true
+      },
+      {
+        "name": "warn-no-paramdoc",
+        "brief": "Warn if parameters are not documented",
+        "details": "When set to `true`, MrDocs outputs a warning message if a named function parameter is not documented.",
         "type": "bool",
         "default": true
       }

--- a/src/lib/Lib/CorpusImpl.cpp
+++ b/src/lib/Lib/CorpusImpl.cpp
@@ -600,12 +600,7 @@ CorpusImpl::finalize()
     report::debug("Finalizing javadoc");
     JavadocFinalizer finalizer(*this);
     finalizer.build();
-
-    if (!config->extractAll && config->warnIfUndocumented)
-    {
-        finalizer.warnUndocumented();
-    }
-    undocumented_.clear();
+    finalizer.emitWarnings();
 }
 
 

--- a/src/lib/Lib/CorpusImpl.cpp
+++ b/src/lib/Lib/CorpusImpl.cpp
@@ -524,7 +524,9 @@ build(
     }
 
     MRDOCS_TRY(auto results, context.results());
+    auto undocumented = context.undocumented();
     corpus->info_ = std::move(results);
+    corpus->undocumented_ = std::move(undocumented);
 
     report::info(
         "Extracted {} declarations in {}",
@@ -598,6 +600,12 @@ CorpusImpl::finalize()
     report::debug("Finalizing javadoc");
     JavadocFinalizer finalizer(*this);
     finalizer.build();
+
+    if (!config->extractAll && config->warnIfUndocumented)
+    {
+        finalizer.warnUndocumented();
+    }
+    undocumented_.clear();
 }
 
 

--- a/src/lib/Lib/CorpusImpl.hpp
+++ b/src/lib/Lib/CorpusImpl.hpp
@@ -16,15 +16,16 @@
 #include "lib/Lib/ConfigImpl.hpp"
 #include "lib/Lib/Info.hpp"
 #include "lib/Support/Debug.hpp"
-#include <map>
-#include <mutex>
-#include <string>
 #include <clang/Tooling/CompilationDatabase.h>
 #include <mrdocs/ADT/UnorderedStringMap.hpp>
 #include <mrdocs/Corpus.hpp>
 #include <mrdocs/Metadata.hpp>
 #include <mrdocs/Platform.hpp>
 #include <mrdocs/Support/Error.hpp>
+#include <map>
+#include <mutex>
+#include <string>
+#include <set>
 
 namespace clang::mrdocs {
 
@@ -44,6 +45,9 @@ class CorpusImpl final : public Corpus
 
     // Info keyed on Symbol ID.
     InfoSet info_;
+
+    // Undocumented symbols
+    UndocumentedInfoSet undocumented_;
 
     // Lookup cache
     // The key represents the context symbol ID.

--- a/src/lib/Lib/ExecutionContext.hpp
+++ b/src/lib/Lib/ExecutionContext.hpp
@@ -23,8 +23,7 @@
 #include <unordered_map>
 #include <vector>
 
-namespace clang {
-namespace mrdocs {
+namespace clang::mrdocs {
 
 /** A custom execution context for visitation.
 
@@ -81,7 +80,8 @@ public:
     void
     report(
         InfoSet&& info,
-        Diagnostics&& diags) = 0;
+        Diagnostics&& diags,
+        UndocumentedInfoSet&& undocumented) = 0;
 
     /** Called when the execution is complete.
 
@@ -104,6 +104,10 @@ public:
     virtual
     mrdocs::Expected<InfoSet>
     results() = 0;
+
+    virtual
+    UndocumentedInfoSet
+    undocumented() = 0;
 };
 
 // ----------------------------------------------------------------
@@ -120,6 +124,7 @@ class InfoExecutionContext
     std::shared_mutex mutex_;
     Diagnostics diags_;
     InfoSet info_;
+    UndocumentedInfoSet undocumented_;
 
 public:
     using ExecutionContext::ExecutionContext;
@@ -128,7 +133,8 @@ public:
     void
     report(
         InfoSet&& info,
-        Diagnostics&& diags) override;
+        Diagnostics&& diags,
+        UndocumentedInfoSet&& undocumented) override;
 
     /// @copydoc ExecutionContext::reportEnd
     void
@@ -144,11 +150,13 @@ public:
 
         @return The results of the execution.
     */
-    mrdocs::Expected<InfoSet>
+    Expected<InfoSet>
     results() override;
+
+    UndocumentedInfoSet
+    undocumented() override;
 };
 
-} // mrdocs
-} // clang
+} // clang::mrdocs
 
 #endif

--- a/src/lib/Lib/Info.hpp
+++ b/src/lib/Lib/Info.hpp
@@ -116,6 +116,51 @@ struct InfoPtrEqual
 using InfoSet = std::unordered_set<
     std::unique_ptr<Info>, InfoPtrHasher, InfoPtrEqual>;
 
+struct SymbolIDNameHasher {
+    using is_transparent = void;
+
+    std::size_t
+    operator()(SymbolID const& I) const {
+        return std::hash<SymbolID>()(I);
+    }
+
+    std::size_t
+    operator()(std::pair<SymbolID, std::string> const& I) const {
+        return std::hash<SymbolID>()(I.first);
+    }
+};
+
+struct SymbolIDNameEqual {
+    using is_transparent = void;
+
+    bool
+    operator()(
+        std::pair<SymbolID, std::string> const& a,
+        std::pair<SymbolID, std::string> const& b) const
+    {
+        return a.first == b.first;
+    }
+
+    bool
+    operator()(
+        std::pair<SymbolID, std::string> const& a,
+        SymbolID const& b) const
+    {
+        return a.first == b;
+    }
+
+    bool
+    operator()(
+        SymbolID const& a,
+        std::pair<SymbolID, std::string> const& b) const
+    {
+        return a == b.first;
+    }
+};
+
+using UndocumentedInfoSet = std::unordered_set<
+    std::pair<SymbolID, std::string>, SymbolIDNameHasher, SymbolIDNameEqual>;
+
 } // clang::mrdocs
 
 #endif

--- a/src/lib/Metadata/Finalizers/JavadocFinalizer.cpp
+++ b/src/lib/Metadata/Finalizers/JavadocFinalizer.cpp
@@ -517,6 +517,7 @@ emitWarnings() const
     warnUndocumented();
     warnDocErrors();
     warnNoParamDocs();
+    warnUndocEnumValues();
 }
 
 void
@@ -683,5 +684,24 @@ warnNoParamDocs(FunctionInfo const& I) const
     }
 }
 
+void
+JavadocFinalizer::
+warnUndocEnumValues() const
+{
+    MRDOCS_CHECK_OR(corpus_.config->warnIfUndocEnumVal);
+    for (auto const& I : corpus_.info_)
+    {
+        MRDOCS_CHECK_OR_CONTINUE(I->isEnumConstant());
+        MRDOCS_CHECK_OR_CONTINUE(I->Extraction == ExtractionMode::Regular);
+        MRDOCS_CHECK_OR_CONTINUE(!I->javadoc);
+        auto primaryLoc = getPrimaryLocation(*I);
+        warn(
+            "{}:{}\n"
+            "{}: Missing documentation for enum value",
+            primaryLoc->FullPath,
+            primaryLoc->LineNumber,
+            corpus_.Corpus::qualifiedName(*I));
+    }
+}
 
 } // clang::mrdocs

--- a/src/lib/Metadata/Finalizers/JavadocFinalizer.cpp
+++ b/src/lib/Metadata/Finalizers/JavadocFinalizer.cpp
@@ -128,7 +128,7 @@ finalize(doc::Reference& ref)
         MRDOCS_ASSERT(current_context_);
         if (auto primaryLoc = getPrimaryLocation(*current_context_))
         {
-            report::warn(
+            warn(
                 "{}:{}\n{}: Failed to resolve reference to '{}'",
                 primaryLoc->FullPath,
                 primaryLoc->LineNumber,
@@ -284,7 +284,7 @@ copyBriefAndDetails(Javadoc& javadoc)
             MRDOCS_ASSERT(current_context_);
             if (auto primaryLoc = getPrimaryLocation(*current_context_))
             {
-                report::warn(
+                warn(
                     "{}:{}\n"
                     "{}: Failed to copy documentation from '{}'\n"
                     "    Note: Symbol '{}' not found.",
@@ -306,7 +306,7 @@ copyBriefAndDetails(Javadoc& javadoc)
         {
             auto ctxPrimaryLoc = getPrimaryLocation(*current_context_);
             auto resPrimaryLoc = getPrimaryLocation(*res);
-            report::warn(
+            warn(
                 "{}:{}\n"
                 "{}: Failed to copy documentation from '{}'.\n"
                 "No documentation available.\n"

--- a/src/lib/Metadata/Finalizers/JavadocFinalizer.hpp
+++ b/src/lib/Metadata/Finalizers/JavadocFinalizer.hpp
@@ -181,6 +181,12 @@ private:
 
     void
     warnParamErrors(FunctionInfo const& I) const;
+
+    void
+    warnNoParamDocs() const;
+
+    void
+    warnNoParamDocs(FunctionInfo const& I) const;
 };
 
 } // clang::mrdocs

--- a/src/lib/Metadata/Finalizers/JavadocFinalizer.hpp
+++ b/src/lib/Metadata/Finalizers/JavadocFinalizer.hpp
@@ -53,6 +53,19 @@ public:
     }
 
     void
+    warnUndocumented() const
+    {
+        for (auto& [id, name] : corpus_.undocumented_)
+        {
+            if (Info const* I = corpus_.find(id))
+            {
+                MRDOCS_CHECK_OR(!I->javadoc || I->Extraction == ExtractionMode::Regular);
+            }
+            warn("{}: Symbol is undocumented", name);
+        }
+    }
+
+    void
     operator()(Info& I)
     {
         visit(I, *this);

--- a/src/lib/Metadata/Finalizers/JavadocFinalizer.hpp
+++ b/src/lib/Metadata/Finalizers/JavadocFinalizer.hpp
@@ -53,17 +53,7 @@ public:
     }
 
     void
-    warnUndocumented() const
-    {
-        for (auto& [id, name] : corpus_.undocumented_)
-        {
-            if (Info const* I = corpus_.find(id))
-            {
-                MRDOCS_CHECK_OR(!I->javadoc || I->Extraction == ExtractionMode::Regular);
-            }
-            warn("{}: Symbol is undocumented", name);
-        }
-    }
+    emitWarnings() const;
 
     void
     operator()(Info& I)
@@ -182,6 +172,15 @@ private:
         MRDOCS_CHECK_OR(corpus_.config->warnings);
         return log(report::Level::warn, format, std::forward<Args>(args)...);
     }
+
+    void
+    warnUndocumented() const;
+
+    void
+    warnDocErrors() const;
+
+    void
+    warnParamErrors(FunctionInfo const& I) const;
 };
 
 } // clang::mrdocs

--- a/src/lib/Metadata/Finalizers/JavadocFinalizer.hpp
+++ b/src/lib/Metadata/Finalizers/JavadocFinalizer.hpp
@@ -187,6 +187,9 @@ private:
 
     void
     warnNoParamDocs(FunctionInfo const& I) const;
+
+    void
+    warnUndocEnumValues() const;
 };
 
 } // clang::mrdocs

--- a/src/lib/Metadata/Finalizers/JavadocFinalizer.hpp
+++ b/src/lib/Metadata/Finalizers/JavadocFinalizer.hpp
@@ -170,7 +170,8 @@ private:
         Args&&... args) const
     {
         MRDOCS_CHECK_OR(corpus_.config->warnings);
-        return log(report::Level::warn, format, std::forward<Args>(args)...);
+        auto const level = !corpus_.config->warnAsError ? report::Level::warn : report::Level::error;
+        return log(level, format, std::forward<Args>(args)...);
     }
 
     void

--- a/src/lib/Metadata/Finalizers/JavadocFinalizer.hpp
+++ b/src/lib/Metadata/Finalizers/JavadocFinalizer.hpp
@@ -159,6 +159,16 @@ private:
                 return corpus_.find(id) != nullptr;
             }));
     }
+
+    template<class... Args>
+    void
+    warn(
+        Located<std::string_view> format,
+        Args&&... args) const
+    {
+        MRDOCS_CHECK_OR(corpus_.config->warnings);
+        return log(report::Level::warn, format, std::forward<Args>(args)...);
+    }
 };
 
 } // clang::mrdocs

--- a/test-files/golden-tests/config/auto-brief/auto-brief.yml
+++ b/test-files/golden-tests/config/auto-brief/auto-brief.yml
@@ -1,2 +1,2 @@
 auto-brief: true
-warnings: false
+warn-broken-ref: false

--- a/test-files/golden-tests/config/auto-brief/auto-brief.yml
+++ b/test-files/golden-tests/config/auto-brief/auto-brief.yml
@@ -1,1 +1,2 @@
 auto-brief: true
+warnings: false

--- a/test-files/golden-tests/config/auto-brief/no-auto-brief.yml
+++ b/test-files/golden-tests/config/auto-brief/no-auto-brief.yml
@@ -1,2 +1,2 @@
 auto-brief: false
-warnings: false
+warn-broken-ref: false

--- a/test-files/golden-tests/config/auto-brief/no-auto-brief.yml
+++ b/test-files/golden-tests/config/auto-brief/no-auto-brief.yml
@@ -1,1 +1,2 @@
 auto-brief: false
+warnings: false

--- a/test-files/golden-tests/config/extract-all/no-extract-all.adoc
+++ b/test-files/golden-tests/config/extract-all/no-extract-all.adoc
@@ -1,0 +1,58 @@
+= Reference
+:mrdocs:
+
+[#index]
+== Global namespace
+
+
+=== Functions
+
+[cols=2]
+|===
+| Name | Description 
+
+| <<docFunction,`docFunction`>> 
+| Documented function
+
+| <<sometimesDocFunction,`sometimesDocFunction`>> 
+| Sometimes documented function
+
+|===
+
+[#docFunction]
+== docFunction
+
+
+Documented function
+
+=== Synopsis
+
+
+Declared in `&lt;no&hyphen;extract&hyphen;all&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+void
+docFunction();
+----
+
+[#sometimesDocFunction]
+== sometimesDocFunction
+
+
+Sometimes documented function
+
+=== Synopsis
+
+
+Declared in `&lt;no&hyphen;extract&hyphen;all&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+void
+sometimesDocFunction();
+----
+
+
+
+[.small]#Created with https://www.mrdocs.com[MrDocs]#

--- a/test-files/golden-tests/config/extract-all/no-extract-all.cpp
+++ b/test-files/golden-tests/config/extract-all/no-extract-all.cpp
@@ -1,0 +1,9 @@
+void undocFunction();
+
+/// Documented function
+void docFunction();
+
+void sometimesDocFunction();
+
+/// Sometimes documented function
+void sometimesDocFunction();

--- a/test-files/golden-tests/config/extract-all/no-extract-all.html
+++ b/test-files/golden-tests/config/extract-all/no-extract-all.html
@@ -1,0 +1,78 @@
+<html lang="en">
+<head>
+<title>Reference</title>
+</head>
+<body>
+<div>
+<h1>Reference</h1>
+<div>
+<div>
+<h2 id="index">Global namespace</h2>
+</div>
+<h2>Functions</h2>
+<table style="table-layout: fixed; width: 100%;">
+<thead>
+<tr>
+<th>Name</th><th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a href="#docFunction"><code>docFunction</code></a> </td><td><span><span>Documented function</span></span>
+
+</td></tr><tr>
+<td><a href="#sometimesDocFunction"><code>sometimesDocFunction</code></a> </td><td><span><span>Sometimes documented function</span></span>
+
+</td></tr>
+</tbody>
+</table>
+</div>
+<div>
+<div>
+<h2 id="docFunction">docFunction</h2>
+<div>
+<span><span>Documented function</span></span>
+
+
+</div>
+</div>
+<div>
+<h3>Synopsis</h3>
+<div>
+Declared in <code>&lt;no-extract-all.cpp&gt;</code></div>
+<pre>
+<code class="source-code cpp">
+void
+docFunction();
+</code>
+</pre>
+</div>
+</div>
+<div>
+<div>
+<h2 id="sometimesDocFunction">sometimesDocFunction</h2>
+<div>
+<span><span>Sometimes documented function</span></span>
+
+
+</div>
+</div>
+<div>
+<h3>Synopsis</h3>
+<div>
+Declared in <code>&lt;no-extract-all.cpp&gt;</code></div>
+<pre>
+<code class="source-code cpp">
+void
+sometimesDocFunction();
+</code>
+</pre>
+</div>
+</div>
+
+</div>
+<div>
+<h4>Created with <a href="https://www.mrdocs.com">MrDocs</a></h4>
+</div>
+</body>
+</html>

--- a/test-files/golden-tests/config/extract-all/no-extract-all.xml
+++ b/test-files/golden-tests/config/extract-all/no-extract-all.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mrdocs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="https://github.com/cppalliance/mrdocs/raw/develop/mrdocs.rnc">
+<namespace id="//////////////////////////8=">
+  <function name="docFunction" id="5x56dR04az7i0nZ7FnDVQhMFz4w=">
+    <file short-path="no-extract-all.cpp" source-path="no-extract-all.cpp" line="4"/>
+    <doc>
+      <brief>
+        <text>Documented function</text>
+      </brief>
+    </doc>
+  </function>
+  <function name="sometimesDocFunction" id="zfmhYS+B5jkLgBi5x/Ciuh0zH6Y=">
+    <file short-path="no-extract-all.cpp" source-path="no-extract-all.cpp" line="9"/>
+    <doc>
+      <brief>
+        <text>Sometimes documented function</text>
+      </brief>
+    </doc>
+  </function>
+</namespace>
+</mrdocs>

--- a/test-files/golden-tests/config/extract-all/no-extract-all.yml
+++ b/test-files/golden-tests/config/extract-all/no-extract-all.yml
@@ -1,1 +1,2 @@
 extract-all: false
+warn-if-undocumented: false

--- a/test-files/golden-tests/config/extract-all/no-extract-all.yml
+++ b/test-files/golden-tests/config/extract-all/no-extract-all.yml
@@ -1,0 +1,1 @@
+extract-all: false

--- a/test-files/golden-tests/config/inherit-base-members/copy-dependencies.yml
+++ b/test-files/golden-tests/config/inherit-base-members/copy-dependencies.yml
@@ -1,3 +1,4 @@
 inherit-base-members: copy-dependencies
 exclude-symbols:
   - excluded_base
+warn-no-paramdoc: false

--- a/test-files/golden-tests/config/inherit-base-members/copy.yml
+++ b/test-files/golden-tests/config/inherit-base-members/copy.yml
@@ -1,3 +1,4 @@
 inherit-base-members: copy-all
 exclude-symbols:
   - excluded_base
+warn-no-paramdoc: false

--- a/test-files/golden-tests/config/inherit-base-members/never.yml
+++ b/test-files/golden-tests/config/inherit-base-members/never.yml
@@ -1,3 +1,4 @@
 inherit-base-members: never
 exclude-symbols:
   - excluded_base
+warn-no-paramdoc: false

--- a/test-files/golden-tests/config/inherit-base-members/reference.yml
+++ b/test-files/golden-tests/config/inherit-base-members/reference.yml
@@ -1,3 +1,4 @@
 inherit-base-members: reference
 exclude-symbols:
   - excluded_base
+warn-no-paramdoc: false

--- a/test-files/golden-tests/filters/symbol-name/extraction-mode.yml
+++ b/test-files/golden-tests/filters/symbol-name/extraction-mode.yml
@@ -29,3 +29,4 @@ implementation-defined:
   - 'excluded_ns::implementation_defined'
   - 'implementation_defined_ns'
   - 'implementation_defined'
+warn-no-paramdoc: false

--- a/test-files/golden-tests/javadoc/inline/styled.adoc
+++ b/test-files/golden-tests/javadoc/inline/styled.adoc
@@ -76,6 +76,17 @@ compare(<<A,A>> const& other) const noexcept;
 
 `&hyphen;1` if `&ast;this &lt; other`, `0` if        `this &equals;&equals; other`, and 1 if `this &gt; other`&period;
 
+=== Parameters
+
+
+|===
+| Name | Description
+
+| *other*
+| The other object to compare against&period;
+
+|===
+
 
 
 [.small]#Created with https://www.mrdocs.com[MrDocs]#

--- a/test-files/golden-tests/javadoc/inline/styled.cpp
+++ b/test-files/golden-tests/javadoc/inline/styled.cpp
@@ -2,15 +2,17 @@
 
     Paragraph with `code`, *bold* text, and _italic_ text.
 
-	We can also escape these markers: \`, \*, and \_.
+    We can also escape these markers: \`, \*, and \_.
 
  */
 struct A {
     /** Compare function
 
-	    @return `-1` if `*this < other`, `0` if
+        @param other The other object to compare against.
+
+	@return `-1` if `*this < other`, `0` if
         `this == other`, and 1 if `this > other`.
-	 */
+     */
     int compare(A const& other) const noexcept;
 };
 

--- a/test-files/golden-tests/javadoc/inline/styled.html
+++ b/test-files/golden-tests/javadoc/inline/styled.html
@@ -92,6 +92,24 @@ compare(<a href="#A">A</a> const& other) const noexcept;
 <p><code>-1</code><span> if </span><code>*this &lt; other</code> <span>, </span><code>0</code><span> if        </span><code>this &#x3D;&#x3D; other</code> <span>, and 1 if </span><code>this &gt; other</code> <span>.</span></p>
 
 </div>
+<div>
+<h3>Parameters</h3>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>other</strong></td>
+<td><p><span>The other object to compare against.</span></p>
+</td>
+</tr>
+</tbody>
+</table>
+</div>
 </div>
 
 </div>

--- a/test-files/golden-tests/javadoc/inline/styled.xml
+++ b/test-files/golden-tests/javadoc/inline/styled.xml
@@ -22,7 +22,7 @@
       </para>
     </doc>
     <function name="compare" exception-spec="noexcept" id="CKPqawUTt6FNIN9qEFTMcdnvPkI=">
-      <file short-path="styled.cpp" source-path="styled.cpp" line="14"/>
+      <file short-path="styled.cpp" source-path="styled.cpp" line="16"/>
       <attr id="is-const"/>
       <return>
         <type name="int"/>
@@ -48,6 +48,9 @@
           <mono>this &gt; other</mono>
           <text>.</text>
         </returns>
+        <param name="other">
+          <text>The other object to compare against.</text>
+        </param>
       </doc>
     </function>
   </struct>

--- a/test-files/golden-tests/javadoc/param/param-direction.yml
+++ b/test-files/golden-tests/javadoc/param/param-direction.yml
@@ -1,0 +1,1 @@
+warn-if-doc-error: false

--- a/test-files/golden-tests/javadoc/param/param-duplicate.yml
+++ b/test-files/golden-tests/javadoc/param/param-duplicate.yml
@@ -1,0 +1,1 @@
+warn-if-doc-error: false

--- a/test-files/golden-tests/javadoc/ref/broken-ref.yml
+++ b/test-files/golden-tests/javadoc/ref/broken-ref.yml
@@ -1,0 +1,1 @@
+warnings: false

--- a/test-files/golden-tests/javadoc/ref/broken-ref.yml
+++ b/test-files/golden-tests/javadoc/ref/broken-ref.yml
@@ -1,1 +1,1 @@
-warnings: false
+warn-broken-ref: false

--- a/test-files/golden-tests/javadoc/ref/operator-param.adoc
+++ b/test-files/golden-tests/javadoc/ref/operator-param.adoc
@@ -93,6 +93,11 @@ bool
 operator()(char ch) const noexcept;
 ----
 
+=== Return Value
+
+
+True if ch is in the set, otherwise false&period;
+
 === Parameters
 
 
@@ -128,6 +133,11 @@ operator()(unsigned char ch) const noexcept;
 This function returns true if the        character is in the set, otherwise        it returns false&period;
 
 
+
+=== Return Value
+
+
+True if ch is in the set, otherwise false&period;
 
 === Parameters
 

--- a/test-files/golden-tests/javadoc/ref/operator-param.adoc
+++ b/test-files/golden-tests/javadoc/ref/operator-param.adoc
@@ -73,7 +73,7 @@ bool
 | Name | Description
 
 | *ch*
-| The character to test&period;
+| The signed character to test&period;
 
 |===
 
@@ -92,6 +92,17 @@ constexpr
 bool
 operator()(char ch) const noexcept;
 ----
+
+=== Parameters
+
+
+|===
+| Name | Description
+
+| *ch*
+| The signed character to test&period;
+
+|===
 
 [#A-operator_call-0b]
 == <<A,A>>::operator()
@@ -125,7 +136,7 @@ This function returns true if the        character is in the set, otherwise     
 | Name | Description
 
 | *ch*
-| The character to test&period;
+| The unsigned character to test&period;
 
 |===
 

--- a/test-files/golden-tests/javadoc/ref/operator-param.cpp
+++ b/test-files/golden-tests/javadoc/ref/operator-param.cpp
@@ -5,13 +5,17 @@ struct A {
         character is in the set, otherwise
         it returns false.
 
-        @param ch The character to test.
+        @param ch The unsigned character to test.
     */
     constexpr
     bool
     operator()(unsigned char ch) const noexcept;
 
-    /// @copydoc A::operator()(unsigned char) const
+    /**
+        @copydoc A::operator()(unsigned char) const
+
+        @param ch The signed character to test.
+     */
     constexpr
     bool
     operator()(char ch) const noexcept;

--- a/test-files/golden-tests/javadoc/ref/operator-param.cpp
+++ b/test-files/golden-tests/javadoc/ref/operator-param.cpp
@@ -6,6 +6,8 @@ struct A {
         it returns false.
 
         @param ch The unsigned character to test.
+
+        @return True if ch is in the set, otherwise false.
     */
     constexpr
     bool
@@ -15,6 +17,8 @@ struct A {
         @copydoc A::operator()(unsigned char) const
 
         @param ch The signed character to test.
+
+        @return True if ch is in the set, otherwise false.
      */
     constexpr
     bool

--- a/test-files/golden-tests/javadoc/ref/operator-param.html
+++ b/test-files/golden-tests/javadoc/ref/operator-param.html
@@ -89,7 +89,7 @@ bool
 <tbody>
 <tr>
 <td><strong>ch</strong></td>
-<td><p><span>The character to test.</span></p>
+<td><p><span>The signed character to test.</span></p>
 </td>
 </tr>
 </tbody>
@@ -111,6 +111,24 @@ bool
 operator()(char ch) const noexcept;
 </code>
 </pre>
+</div>
+<div>
+<h3>Parameters</h3>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>ch</strong></td>
+<td><p><span>The signed character to test.</span></p>
+</td>
+</tr>
+</tbody>
+</table>
 </div>
 </div>
 <div>
@@ -152,7 +170,7 @@ operator()(unsigned char ch) const noexcept;
 <tbody>
 <tr>
 <td><strong>ch</strong></td>
-<td><p><span>The character to test.</span></p>
+<td><p><span>The unsigned character to test.</span></p>
 </td>
 </tr>
 </tbody>

--- a/test-files/golden-tests/javadoc/ref/operator-param.html
+++ b/test-files/golden-tests/javadoc/ref/operator-param.html
@@ -113,6 +113,11 @@ operator()(char ch) const noexcept;
 </pre>
 </div>
 <div>
+<h3>Return Value</h3>
+<p><span>True if ch is in the set, otherwise false.</span></p>
+
+</div>
+<div>
 <h3>Parameters</h3>
 <table>
 <thead>
@@ -156,6 +161,11 @@ operator()(unsigned char ch) const noexcept;
 <h3>Description</h3>
 <p><span>This function returns true if the        character is in the set, otherwise        it returns false.</span></p>
 
+
+</div>
+<div>
+<h3>Return Value</h3>
+<p><span>True if ch is in the set, otherwise false.</span></p>
 
 </div>
 <div>

--- a/test-files/golden-tests/javadoc/ref/operator-param.xml
+++ b/test-files/golden-tests/javadoc/ref/operator-param.xml
@@ -5,7 +5,7 @@
   <struct name="A" id="YrPSaKAbmXgzCAX5WByx4eVoqBM=">
     <file short-path="operator-param.cpp" source-path="operator-param.cpp" line="1" class="def"/>
     <function name="operator()" exception-spec="noexcept" id="+yVVNLbCaXDXfZPFoKE5xv2xPZQ=">
-      <file short-path="operator-param.cpp" source-path="operator-param.cpp" line="19"/>
+      <file short-path="operator-param.cpp" source-path="operator-param.cpp" line="23"/>
       <attr id="constexpr-kind" name="constexpr" value="1"/>
       <attr id="operator" name="call" value="42"/>
       <attr id="is-const"/>
@@ -16,13 +16,16 @@
         <type name="char"/>
       </param>
       <doc>
+        <returns>
+          <text>True if ch is in the set, otherwise false.</text>
+        </returns>
         <param name="ch">
           <text>The signed character to test.</text>
         </param>
       </doc>
     </function>
     <function name="operator()" exception-spec="noexcept" id="tslXb2aqh8tYThe+A16a9felw5M=">
-      <file short-path="operator-param.cpp" source-path="operator-param.cpp" line="10"/>
+      <file short-path="operator-param.cpp" source-path="operator-param.cpp" line="12"/>
       <attr id="constexpr-kind" name="constexpr" value="1"/>
       <attr id="operator" name="call" value="42"/>
       <attr id="is-const"/>
@@ -39,6 +42,9 @@
         <para>
           <text>This function returns true if the        character is in the set, otherwise        it returns false.</text>
         </para>
+        <returns>
+          <text>True if ch is in the set, otherwise false.</text>
+        </returns>
         <param name="ch">
           <text>The unsigned character to test.</text>
         </param>

--- a/test-files/golden-tests/javadoc/ref/operator-param.xml
+++ b/test-files/golden-tests/javadoc/ref/operator-param.xml
@@ -5,7 +5,7 @@
   <struct name="A" id="YrPSaKAbmXgzCAX5WByx4eVoqBM=">
     <file short-path="operator-param.cpp" source-path="operator-param.cpp" line="1" class="def"/>
     <function name="operator()" exception-spec="noexcept" id="+yVVNLbCaXDXfZPFoKE5xv2xPZQ=">
-      <file short-path="operator-param.cpp" source-path="operator-param.cpp" line="15"/>
+      <file short-path="operator-param.cpp" source-path="operator-param.cpp" line="19"/>
       <attr id="constexpr-kind" name="constexpr" value="1"/>
       <attr id="operator" name="call" value="42"/>
       <attr id="is-const"/>
@@ -16,6 +16,9 @@
         <type name="char"/>
       </param>
       <doc>
+        <param name="ch">
+          <text>The signed character to test.</text>
+        </param>
       </doc>
     </function>
     <function name="operator()" exception-spec="noexcept" id="tslXb2aqh8tYThe+A16a9felw5M=">
@@ -37,7 +40,7 @@
           <text>This function returns true if the        character is in the set, otherwise        it returns false.</text>
         </para>
         <param name="ch">
-          <text>The character to test.</text>
+          <text>The unsigned character to test.</text>
         </param>
       </doc>
     </function>

--- a/test-files/golden-tests/metadata/enum.yml
+++ b/test-files/golden-tests/metadata/enum.yml
@@ -1,0 +1,1 @@
+warn-if-undoc-enum-val: false

--- a/test-files/golden-tests/metadata/sfinae.yml
+++ b/test-files/golden-tests/metadata/sfinae.yml
@@ -1,1 +1,2 @@
 warn-if-doc-error: false
+warn-no-paramdoc: false

--- a/test-files/golden-tests/metadata/sfinae.yml
+++ b/test-files/golden-tests/metadata/sfinae.yml
@@ -1,0 +1,1 @@
+warn-if-doc-error: false


### PR DESCRIPTION
This PR replicates all warning options available in Doxygen. It also includes an extra option for broken refs.