### PR TITLE
fix: merge namespaces when collecting results

### DIFF
--- a/src/lib/Lib/ExecutionContext.cpp
+++ b/src/lib/Lib/ExecutionContext.cpp
@@ -13,7 +13,9 @@
 
 #include "ExecutionContext.hpp"
 #include "lib/Metadata/Reduce.hpp"
+#include "mrdocs/Support/Assert.hpp"
 #include <mrdocs/Metadata.hpp>
+#include <mrdocs/Metadata/Info/Namespace.hpp>
 #include <ranges>
 
 namespace clang {
@@ -69,7 +71,11 @@ report(
     {
         auto it = info_.find(other->id);
         MRDOCS_ASSERT(it != info_.end());
-        merge(**it, std::move(*other));
+        visit(**it, [&]<typename T>(T& target) {
+            auto *source = dynamic_cast<T*>(other.get());
+            MRDOCS_ASSERT(source);
+            merge(target, std::move(*source));
+        });
     }
 
     // Merge diagnostics and report any new messages.


### PR DESCRIPTION
I'm not 100% sure if this is the correct approach. I would guess that something like this already happens somewhere, but I couldn't find anything.

When using multiple sources (→ multiple extraction jobs), then only the first one will be "visible", because its global namespace/global symbol will be the only one that gets merged with `info_.merge(info)`. All other global namespaces will be discarded, because there's already one present. Their members will still be in the corpus, but there's no path from the global symbol to them.

Because of ODR, only namespaces have to be merged.