### PR TITLE
fix(clang-cl): reduce warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -276,11 +276,12 @@ if (WIN32)
         target_compile_options(
             mrdocs-core
             PUBLIC
-            /permissive-    # strict C++
-            /W4             # enable all warnings
-            /MP             # multi-processor compilation
-            /EHs            # C++ Exception handling
-            $<$<CONFIG:Debug>:/Oy-> # Disable frame pointer omission
+            /permissive-                    # strict C++
+            /W4                             # enable all warnings
+            $<$<CXX_COMPILER_ID:MSVC>:/MP>  # multi-processor compilation
+            /EHs                            # C++ Exception handling
+            $<$<CONFIG:Debug>:/Oy->         # Disable frame pointer omission
+            $<$<CXX_COMPILER_ID:Clang>:-Wno-unused-parameter>  # ClangCL warning enabled with /W4
         )
     endif()
 endif ()

--- a/src/lib/Support/LegibleNames.cpp
+++ b/src/lib/Support/LegibleNames.cpp
@@ -192,7 +192,7 @@ public:
         If the symbolhas no name, then a reserved name based
         on the type is returned instead.
      */
-    std::string_view
+    std::string
     getRawUnqualified(SymbolID const& id)
     {
         Info const* I = corpus_.find(id);

--- a/src/test/ADT/Polymorphic.cpp
+++ b/src/test/ADT/Polymorphic.cpp
@@ -241,8 +241,8 @@ struct Polymorphic_test
 #if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wself-assign-overloaded"
-#endif
-#if defined(__GNUC__)
+#pragma clang diagnostic ignored "-Wself-move"
+#elif defined(__GNUC__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wself-move"
 #endif
@@ -255,8 +255,7 @@ struct Polymorphic_test
             }
 #if defined(__clang__)
 #pragma clang diagnostic pop
-#endif
-#if defined(__GNUC__)
+#elif defined(__GNUC__)
 #pragma GCC diagnostic pop
 #endif
 


### PR DESCRIPTION
When compiling with clang-cl, there are warnings not present with MSVC

- `/MP` isn't a thing in clang-cl.
- `/W4` enables `-Wunused-parameter` in clang-cl (or this might be enabled by default) - either way, it's not enabled in MSVC and generates some warnings here.
- `getRawUnqualified` returned a `std::string_view` to a temporary `std::string` and clang warned about it.
- `-Wself-move` was ignored when `__GNUC__` was defined. This isn't defined with clang-cl, so ignore it in the clang block.