### PR TITLE
fix: crash on unimplemented when populating overloads destructor entry

### DIFF
--- a/src/lib/Metadata/Finalizers/OverloadsFinalizer.cpp
+++ b/src/lib/Metadata/Finalizers/OverloadsFinalizer.cpp
@@ -105,6 +105,7 @@ foldOverloads(SymbolID const& contextId, std::vector<SymbolID>& functionIds, boo
         MRDOCS_CHECK_OR_CONTINUE(recordInfoPtr);
         auto* function = recordInfoPtr->asFunctionPtr();
         MRDOCS_CHECK_OR_CONTINUE(function);
+        MRDOCS_CHECK_OR_CONTINUE(function->Class != FunctionClass::Destructor);
 
         // Check if the FunctionInfo is unique
         std::ranges::subrange otherFunctionIds(

--- a/src/lib/Metadata/Info/Overloads.cpp
+++ b/src/lib/Metadata/Info/Overloads.cpp
@@ -44,6 +44,8 @@ merge(OverloadsInfo& I, OverloadsInfo&& Other)
 void
 addMember(OverloadsInfo& I, FunctionInfo const& Member)
 {
+    MRDOCS_ASSERT(Member.Class != FunctionClass::Destructor);
+
     if (I.Members.empty())
     {
         I.Name = Member.Name;


### PR DESCRIPTION
I am not sure why this is not seen in CI presently, but I can reproduce it when building mrdocs from the llvm version bundled in homebrew (currently 20.1.7).