### PR TITLE
fix: replace uses of deprecated fmt::has_formatter

### DIFF
--- a/include/mrdocs/Support/Handlebars.hpp
+++ b/include/mrdocs/Support/Handlebars.hpp
@@ -218,13 +218,10 @@ public:
         @return A reference to this object
      */
     template <class T>
-    requires fmt::has_formatter<T, fmt::format_context>::value
-    friend
-    OutputRef&
-    operator<<( OutputRef& os, T v )
-    {
-        std::string s = fmt::format( "{}", v );
-        return os.write_impl( s );
+      requires fmt::is_formattable<T>::value
+    friend OutputRef &operator<<(OutputRef &os, T v) {
+      std::string s = fmt::format("{}", v);
+      return os.write_impl(s);
     }
 
     void

--- a/src/test_suite/detail/decomposer.hpp
+++ b/src/test_suite/detail/decomposer.hpp
@@ -53,7 +53,7 @@ namespace test_suite::detail
             out += '\"';
         }
 #ifdef MRDOCS_TEST_HAS_FMT
-        if constexpr (fmt::has_formatter<T, fmt::format_context>::value) {
+        if constexpr (fmt::is_formattable<T>::value) {
             out += fmt::format("{}", value);
         } else
 #endif


### PR DESCRIPTION
use is_formattable instead.

has_formatter was never a good API, since it only asked if the type has a `formatter` specialization, but a type can also be formattable if it provides an implicit conversion to a type which does.

The newer API takes care of the that problem.