### PR TITLE
ci: enable ubsan for clang and gcc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,8 @@ jobs:
           standards: '20'
           latest-factors: |
             msvc Optimized-Debug
-            gcc Coverage
+            gcc UBSan Coverage
+            clang UBSan
           factors: ''
           runs-on: |
             apple-clang: macos-15
@@ -65,21 +66,21 @@ jobs:
             msvc: ''
           extra-values: |
             llvm-hash: dd7a3d4d798e30dfe53b5bbbbcd9a23c24ea1af9
-            llvm-id: {{ substr llvm-hash 0 7 }}
-            llvm-build-preset-prefix: {{#if optimized-debug}}debwithopt{{else}}{{lowercase build-type}}{{/if}}
-            llvm-build-preset-suffix: {{#if (ieq os 'windows') }}win{{else}}unix{{/if}}
-            llvm-build-preset: {{ llvm-build-preset-prefix }}-{{ llvm-build-preset-suffix }}
-            llvm-compiler-key: {{ compiler }}-{{ version }}
-            llvm-cache-key: llvm-libcxx-{{ lowercase os }}-{{ llvm-compiler-key }}-{{ llvm-build-preset-prefix }}-{{ llvm-hash }}
+            llvm-build-preset-prefix: {{#if optimized-debug}}debwithopt{{else}}{{{lowercase build-type}}}{{/if}}
+            llvm-build-preset-os: {{#if (ieq os 'windows') }}win{{else}}unix{{/if}}
+            llvm-sanitizer: {{#if ubsan}}-UBSan{{else if asan}}-ASan{{else if msan}}-MSan{{/if}}
+            llvm-build-preset: {{{ llvm-build-preset-prefix }}}-{{{ llvm-build-preset-os }}}
+            llvm-compiler-version: {{#if (or (contains version '*') (contains version '^'))}}{{else}}-{{{ version }}}{{/if}}
+            llvm-archive-basename: llvm-{{{ lowercase os }}}-{{{ compiler }}}{{{ llvm-compiler-version }}}-{{{ llvm-build-preset-prefix }}}{{{ sanitizer }}}-{{{ substr llvm-hash 0 7 }}}
             llvm-root: ../third-party/llvm-project/install
-            llvm-archive-basename: llvm-{{ os }}-{{ llvm-build-preset-prefix }}-{{ llvm-id }}
             llvm-archive-extension: {{#if (ieq os 'windows') }}7z{{else}}tar.bz2{{/if}}
-            llvm-archive-filename: {{ llvm-archive-basename }}.{{ llvm-archive-extension }}
-            mrdocs-ccflags: {{ ccflags }} {{#if (eq compiler 'gcc') }}-static{{/if}} {{#if asan }}-static-libasan{{/if}} {{#if tsan }}-static-libtsan{{/if}}
-            mrdocs-cxxflags: {{ cxxflags }} {{#if (eq compiler 'gcc') }}-static{{/if}} {{#if asan }}-static-libasan{{/if}} {{#if tsan }}-static-libtsan{{/if}}
+            llvm-archive-filename: {{{ llvm-archive-basename }}}.{{{ llvm-archive-extension }}}
+            mrdocs-ccflags: {{{ ccflags }}} {{#if (and (eq compiler 'gcc') (not asan)) }}-static{{/if}}
+            mrdocs-cxxflags: {{{ cxxflags }}} {{#if (and (eq compiler 'gcc') (not asan)) }}-static{{/if}}
             mrdocs-package-generators: {{#if (ieq os 'windows') }}7Z ZIP WIX{{else}}TGZ TXZ{{/if}}
-            mrdocs-release-package-artifact: release-packages-{{ lowercase os }}
+            mrdocs-release-package-artifact: release-packages-{{{ lowercase os }}}
           output-file: matrix.json
+          trace-commands: true
 
       # Set up the version as expected by the LLVM matrix script and @actions/core
       - name: Setup Node.js
@@ -211,7 +212,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ steps.resolve-llvm-root.outputs.llvm-root }}
-          key: ${{ matrix.llvm-cache-key }}
+          key: ${{ matrix.llvm-archive-basename }}
 
       - name: Download LLVM Binaries
         id: llvm-download
@@ -260,6 +261,10 @@ jobs:
           build-type: ${{ matrix.build-type }}
           extra-args: |
             ${{ runner.os == 'Windows' && '-DLLVM_ENABLE_RUNTIMES=libcxx' || '-DLLVM_ENABLE_RUNTIMES=libcxx;libcxxabi;libunwind' }}
+            # The UBSan vptr sanitizer needs RTTI.
+            ${{ matrix.ubsan && '-DLLVM_ENABLE_RTTI=ON' }}
+            # The LLVM_USE_SANITIZER option doesn't support GCC.
+            ${{ !matrix.compiler == 'gcc' && matrix.ubsan && '-DLLVM_USE_SANITIZER=Undefined' }}
           cc: ${{ steps.setup-cpp.outputs.cc }}
           cxx: ${{ steps.setup-cpp.outputs.cxx }}
           generator: Ninja
@@ -868,7 +873,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ steps.resolve-llvm-root.outputs.llvm-root }}
-          key: ${{ matrix.llvm-cache-key }}
+          key: ${{ matrix.llvm-archive-basename }}
 
       - name: Compress LLVM
         id: llvm-upload

--- a/src/lib/Metadata/Finalizers/BaseMembersFinalizer.cpp
+++ b/src/lib/Metadata/Finalizers/BaseMembersFinalizer.cpp
@@ -107,11 +107,11 @@ inheritBaseMembers(
         Info& otherInfo = *otherInfoPtr;
 
         // Check if we're not attempt to copy a special member function
-        if (auto const* funcPtr = static_cast<FunctionInfo const*>(otherInfoPtr))
-        {
-            MRDOCS_CHECK_OR_CONTINUE(!is_one_of(
-                funcPtr->Class,
-                { FunctionClass::Constructor, FunctionClass::Destructor }));
+        if (auto const *funcPtr =
+                dynamic_cast<FunctionInfo const *>(otherInfoPtr)) {
+          MRDOCS_CHECK_OR_CONTINUE(
+              !is_one_of(funcPtr->Class, {FunctionClass::Constructor,
+                                          FunctionClass::Destructor}));
         }
 
         // Check if derived class has a member that shadows the base member

--- a/src/lib/Support/Yaml.cpp
+++ b/src/lib/Support/Yaml.cpp
@@ -15,51 +15,33 @@
 namespace clang {
 namespace mrdocs {
 
-void
-YamlReporter::
-diag(
-    llvm::SMDiagnostic const& D)
-{
-    report::Level level = report::Level::debug;
-    switch(D.getKind())
-    {
-    case llvm::SourceMgr::DiagKind::DK_Remark:
-        level = report::Level::debug;
-        break;
-    case llvm::SourceMgr::DiagKind::DK_Note:
-        level = report::Level::info;
-        break;
-    case llvm::SourceMgr::DiagKind::DK_Warning:
-    {
-        if(D.getMessage().starts_with("unknown key "))
-        {
-            // don't show these
-            return;
-        }
-        level = report::Level::warn;
-        break;
+void YamlReporter::diag(llvm::SMDiagnostic const &D, void *) {
+  report::Level level = report::Level::debug;
+  switch (D.getKind()) {
+  case llvm::SourceMgr::DiagKind::DK_Remark:
+    level = report::Level::debug;
+    break;
+  case llvm::SourceMgr::DiagKind::DK_Note:
+    level = report::Level::info;
+    break;
+  case llvm::SourceMgr::DiagKind::DK_Warning: {
+    if (D.getMessage().starts_with("unknown key ")) {
+      // don't show these
+      return;
     }
-    case llvm::SourceMgr::DiagKind::DK_Error:
-        level = report::Level::error;
-        break;
-    default:
-        MRDOCS_UNREACHABLE();
-    }
+    level = report::Level::warn;
+    break;
+  }
+  case llvm::SourceMgr::DiagKind::DK_Error:
+    level = report::Level::error;
+    break;
+  default:
+    MRDOCS_UNREACHABLE();
+  }
 
-    report::call_impl(
-        level,
-        [&](llvm::raw_ostream& os)
-        {
-            D.print("mrdocs", os, true, true);
-        }, nullptr);
-}
-
-void
-YamlReporter::
-diagFnImpl(
-    llvm::SMDiagnostic const& D, void* ctx)
-{
-    reinterpret_cast<YamlReporter*>(ctx)->diag(D);
+  report::call_impl(
+      level, [&](llvm::raw_ostream &os) { D.print("mrdocs", os, true, true); },
+      nullptr);
 }
 
 } // mrdocs

--- a/src/lib/Support/Yaml.hpp
+++ b/src/lib/Support/Yaml.hpp
@@ -21,16 +21,12 @@ namespace mrdocs {
 class MRDOCS_DECL
     YamlReporter
 {
-    void diag(llvm::SMDiagnostic const&);
-    static void diagFnImpl(llvm::SMDiagnostic const&, void*);
+  static void diag(llvm::SMDiagnostic const &, void *);
 
 public:
     typedef void (*diagFn)(llvm::SMDiagnostic const&, void*);
 
-    operator diagFn() const noexcept
-    {
-        return &diagFnImpl;
-    }
+    operator diagFn() const noexcept { return &diag; }
 };
 
 } // mrdocs


### PR DESCRIPTION
And fixes a member function call through a null pointer and an incorrect use of static_cast.