### PR TITLE
Accessibility improvements

### DIFF
--- a/docs/ui/src/partials/logo.hbs
+++ b/docs/ui/src/partials/logo.hbs
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1080 1080">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1080 1080" aria-hidden="true">
     <defs>
         <style>
             .st0{fill:#fff}

--- a/docs/website/index.html.hbs
+++ b/docs/website/index.html.hbs
@@ -36,7 +36,7 @@
 </head>
 
 <body>
-    <nav class="nav container-fluid" role="navigation" aria-label="Main navigation">
+    <nav class="nav container-fluid" aria-label="Main navigation">
         <div class="nav-section">
             <a href="/" class="logo-link" aria-label="MrDocs Home">
                 {{> logo }}
@@ -46,11 +46,11 @@
         <div class="nav-section">
             <ul role="menubar">
             {{#each navbar}}
-            <li role="none"><a href="{{ href }}" class="secondary" role="menuitem">{{ title }}</a></li>
+            <li><a href="{{ href }}" class="secondary">{{ title }}</a></li>
             {{/each}}
             <li>
                 <a href="{{ site.github.url }}" class="contrast" aria-label="{{ site.title}} GitHub repository">
-                        <svg aria-hidden="true" focusable="false" role="img" xmlns="http://www.w3.org/2000/svg"
+                        <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg"
                             viewBox="0 0 496 512" height="16px">
                             <path fill="currentColor"
                                 d="M165.9 397.4c0 2-2.3 3.6-5.2 3.6-3.3.3-5.6-1.3-5.6-3.6 0-2 2.3-3.6 5.2-3.6 3-.3 5.6 1.3 5.6 3.6zm-31.1-4.5c-.7 2 1.3 4.3 4.3 4.9 2.6 1 5.6 0 6.2-2s-1.3-4.3-4.3-5.2c-2.6-.7-5.5.3-6.2 2.3zm44.2-1.7c-2.9.7-4.9 2.6-4.6 4.9.3 2 2.9 3.3 5.9 2.6 2.9-.7 4.9-2.6 4.6-4.6-.3-1.9-3-3.2-5.9-2.9zM244.8 8C106.1 8 0 113.3 0 252c0 110.9 69.8 205.8 169.5 239.2 12.8 2.3 17.3-5.6 17.3-12.1 0-6.2-.3-40.4-.3-61.4 0 0-70 15-84.7-29.8 0 0-11.4-29.1-27.8-36.6 0 0-22.9-15.7 1.6-15.4 0 0 24.9 2 38.6 25.8 21.9 38.6 58.6 27.5 72.9 20.9 2.3-16 8.8-27.1 16-33.7-55.9-6.2-112.3-14.3-112.3-110.5 0-27.5 7.6-41.3 23.6-58.9-2.6-6.5-11.1-33.3 2.6-67.9 20.9-6.5 69 27 69 27 20-5.6 41.5-8.5 62.8-8.5s42.8 2.9 62.8 8.5c0 0 48.1-33.6 69-27 13.7 34.7 5.2 61.4 2.6 67.9 16 17.7 25.8 31.5 25.8 58.9 0 96.5-58.9 104.2-114.8 110.5 9.2 7.9 17 22.9 17 46.4 0 33.7-.3 75.4-.3 83.6 0 6.5 4.6 14.4 17.3 12.1C428.2 457.8 496 362.9 496 252 496 113.3 383.5 8 244.8 8zM97.2 352.9c-1.3 1-1 3.3.7 5.2 1.6 1.6 3.9 2.3 5.2 1 1.3-1 1-3.3-.7-5.2-1.6-1.6-3.9-2.3-5.2-1zm-10.8-8.1c-.7 1.3.3 2.9 2.3 3.9 1.6 1 3.6.7 4.3-.7.7-1.3-.3-2.9-2.3-3.9-2-.6-3.6-.3-4.3.7zm32.4 35.6c-1.6 1.3-1 4.3 1.3 6.2 2.3 2.3 5.2 2.6 6.5 1 1.3-1.3.7-4.3-1.3-6.2-2.2-2.3-5.2-2.6-6.5-1zm-11.4-14.7c-1.6 1-1.6 3.6 0 5.9 1.6 2.3 4.3 3.3 5.6 2.3 1.6-1.3 1.6-3.9 0-6.2-1.4-2.3-4-3.3-5.6-2z"></path>
@@ -66,8 +66,8 @@
                 <h1>{{ title }}</h1>
                 <p>{{ description }}</p>
                 <div class="header-cta">
-                    <a href="docs/" class="secondary" role="button" aria-label="Documentation">Get started</a>
-                    <a href="docs/mrdocs/install.html" class="contrast outline" role="button" aria-label="Download">Download</a>
+                    <a href="docs/" class="secondary" role="button">Get started</a>
+                    <a href="docs/mrdocs/install.html" class="contrast outline" role="button">Download</a>
                 </div>
                 <div class="banner-snippet">
                     <small><code>{{ banner.description }}</code></small>
@@ -102,7 +102,7 @@
                 <div class="grid principles-features">
                     {{#each features}}
                     <div>
-                        <svg aria-hidden="true" focusable="false" role="img" xmlns="http://www.w3.org/2000/svg"
+                        <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg"
                             viewBox="0 0 640 512" height="16px">
                             <path fill="currentColor"
                                 d="M278.9 511.5l-61-17.7c-6.4-1.8-10-8.5-8.2-14.9L346.2 8.7c1.8-6.4 8.5-10 14.9-8.2l61 17.7c6.4 1.8 10 8.5 8.2 14.9L293.8 503.3c-1.9 6.4-8.5 10.1-14.9 8.2zm-114-112.2l43.5-46.4c4.6-4.9 4.3-12.7-.8-17.2L117 256l90.6-79.7c5.1-4.5 5.5-12.3.8-17.2l-43.5-46.4c-4.5-4.8-12.1-5.1-17-.5L3.8 247.2c-5.1 4.7-5.1 12.8 0 17.5l144.1 135.1c4.9 4.6 12.5 4.4 17-.5zm327.2.6l144.1-135.1c5.1-4.7 5.1-12.8 0-17.5L492.1 112.1c-4.8-4.5-12.4-4.3-17 .5L431.6 159c-4.6 4.9-4.3 12.7.8 17.2L523 256l-90.6 79.7c-5.1 4.5-5.5 12.3-.8 17.2l43.5 46.4c4.5 4.9 12.1 5.1 17 .6z">
@@ -167,7 +167,7 @@
             {{/each}}
         </div>
     </section>
-    <section id="star" data-theme="light" aria-label="Star Mr.Docs on GitHub">
+    <section id="star" data-theme="light">
         <div class="container">
             <p>Give us a Star on GitHub:
                 <iframe src="https://ghbtns.com/github-btn.html?user=cppalliance&amp;repo=mrdocs&amp;type=star&amp;count=true&amp;size=large"


### PR DESCRIPTION
This is just a little part of the overall work, but I'd like to receive a feedback before continuing. I'd also like to know which level of Accessibility the website should at least support, since, in some situations, this may also have an impact on the design. My idea is to keep the WCAG 2.2, Level AA. This should be a good trade-off between simplicity for development and a better UX for people with disabilities. Moreover, this should make the website conformant with the EAA (EN 301 549).

The `header-cta` links had "aria-label" attributes that essentially repeated what the information that can be retrieved by the text node. Also, the first link had a mismatch between what there was in the `aria-label` attribute ("Documentation") and what  there's in the text node ("Get Started").

The `menu-bar` unordered list heavily uses the `role` attribute. However, this doesn't seem necessary, since the semantics is already provided by the DOM. If the intention was to remove the semantics of `<li>` to replace it with `<a>`, I think the issue is more related to this [article](https://ivogomes.medium.com/navega%C3%A7%C3%A3o-sem-listas-um-teste-de-acessibilidade-b5d5876ac528).

The `role="navigation"` attribute was used in a `<nav>` tag, even if this is already provided by the tag itself. Indeed, the `<nav>` tag has implicitly the navigation role. If the intention was to keep it for compatibility with browsers that doesn't support HTML5, it should be at least applied consistently.

About the `star` section, there's already a text node, which says "Give us a Star on GitHub", and therefore the use of an `aria-label` attribute that essentially reports the same isn't useful.

Finally, the SVG code in the `logo.hbs` file wasn't hidden with the `aria-hidden` attribute.