### PR TITLE
split record and namespace members sorting criteria

### DIFF
--- a/docs/mrdocs.schema.json
+++ b/docs/mrdocs.schema.json
@@ -419,12 +419,12 @@
     },
     "sort-members": {
       "default": true,
-      "description": "When set to `true`, sort the members of a record or namespace by name and parameters. When set to `false`, the members are included in the declaration order they are extracted.",
+      "description": "When set to `true`, sort the members of a record by the criterion determined in the `sort-members-by` option. When set to `false`, the members are included in the declaration order they are extracted.",
       "enum": [
         true,
         false
       ],
-      "title": "Sort the members of a record or namespace",
+      "title": "Sort the members of a record",
       "type": "boolean"
     },
     "sort-members-assignment-1st": {
@@ -439,12 +439,12 @@
     },
     "sort-members-by": {
       "default": "name",
-      "description": "If `sort-members` is set to `true`, determine how members of a record or namespace are sorted. When set to `name`, members are sorted by name. When set to `location`, members are sorted by their primary location in the source code, considering the short name of the path and the location in the file.",
+      "description": "If `sort-members` is set to `true`, determine how members of a record are sorted. When set to `name`, members are sorted by name. When set to `location`, members are sorted by their primary location in the source code, considering the short name of the path and the location in the file.",
       "enum": [
         "name",
         "location"
       ],
-      "title": "Determine how members of a record or namespace are sorted"
+      "title": "Determine how members of a record are sorted"
     },
     "sort-members-conversion-last": {
       "default": true,
@@ -485,6 +485,15 @@
       ],
       "title": "Sort relational operators last",
       "type": "boolean"
+    },
+    "sort-namespace-members-by": {
+      "default": "name",
+      "description": "Although members of namespaces are always sorted, determine how members of a namespace are sorted. When set to `name`, members are sorted by name. When set to `location`, members are sorted by their primary location in the source code, considering the short name of the path and the location in the file.",
+      "enum": [
+        "name",
+        "location"
+      ],
+      "title": "Determine how members of a namespace are sorted"
     },
     "source-root": {
       "default": "<config-dir>",

--- a/docs/mrdocs.schema.json
+++ b/docs/mrdocs.schema.json
@@ -437,6 +437,15 @@
       "title": "Sort assignment operators first",
       "type": "boolean"
     },
+    "sort-members-by": {
+      "default": "name",
+      "description": "If `sort-members` is set to `true`, determine how members of a record or namespace are sorted. When set to `name`, members are sorted by name. When set to `location`, members are sorted by their primary location in the source code, considering the short name of the path and the location in the file.",
+      "enum": [
+        "name",
+        "location"
+      ],
+      "title": "Determine how members of a record or namespace are sorted"
+    },
     "sort-members-conversion-last": {
       "default": true,
       "description": "When set to `true`, conversion operators are sorted last in the list of members of a record or namespace.",

--- a/src/lib/ConfigOptions.json
+++ b/src/lib/ConfigOptions.json
@@ -277,15 +277,26 @@
       },
       {
         "name": "sort-members",
-        "brief": "Sort the members of a record or namespace",
-        "details": "When set to `true`, sort the members of a record or namespace by name and parameters. When set to `false`, the members are included in the declaration order they are extracted.",
+        "brief": "Sort the members of a record",
+        "details": "When set to `true`, sort the members of a record by the criterion determined in the `sort-members-by` option. When set to `false`, the members are included in the declaration order they are extracted.",
         "type": "bool",
         "default": true
       },
       {
         "name": "sort-members-by",
-        "brief": "Determine how members of a record or namespace are sorted",
-        "details": "If `sort-members` is set to `true`, determine how members of a record or namespace are sorted. When set to `name`, members are sorted by name. When set to `location`, members are sorted by their primary location in the source code, considering the short name of the path and the location in the file.",
+        "brief": "Determine how members of a record are sorted",
+        "details": "If `sort-members` is set to `true`, determine how members of a record are sorted. When set to `name`, members are sorted by name. When set to `location`, members are sorted by their primary location in the source code, considering the short name of the path and the location in the file.",
+        "type": "enum",
+        "values": [
+            "name",
+            "location"
+        ],
+        "default": "name"
+      },
+      {
+        "name": "sort-namespace-members-by",
+        "brief": "Determine how members of a namespace are sorted",
+        "details": "Although members of namespaces are always sorted, determine how members of a namespace are sorted. When set to `name`, members are sorted by name. When set to `location`, members are sorted by their primary location in the source code, considering the short name of the path and the location in the file.",
         "type": "enum",
         "values": [
             "name",

--- a/src/lib/ConfigOptions.json
+++ b/src/lib/ConfigOptions.json
@@ -283,6 +283,17 @@
         "default": true
       },
       {
+        "name": "sort-members-by",
+        "brief": "Determine how members of a record or namespace are sorted",
+        "details": "If `sort-members` is set to `true`, determine how members of a record or namespace are sorted. When set to `name`, members are sorted by name. When set to `location`, members are sorted by their primary location in the source code, considering the short name of the path and the location in the file.",
+        "type": "enum",
+        "values": [
+            "name",
+            "location"
+        ],
+        "default": "name"
+      },
+      {
         "name": "sort-members-ctors-1st",
         "brief": "Sort constructors first",
         "details": "When set to `true`, constructors are sorted first in the list of members of a record.",

--- a/src/lib/CorpusImpl.cpp
+++ b/src/lib/CorpusImpl.cpp
@@ -964,13 +964,15 @@ CorpusImpl::finalize()
         finalizer.build();
     }
 
+    // Add auto relates for member functions
     {
         report::debug("  - Finalizing auto-relates");
         DerivedFinalizer finalizer(*this);
         finalizer.build();
     }
 
-    if (config->sortMembers)
+    // Sort members: this runs unconditionally because
+    // the members of some symbol types are always sorted.
     {
         report::debug("  - Finalizing sorted members");
         SortMembersFinalizer finalizer(*this);
@@ -978,9 +980,11 @@ CorpusImpl::finalize()
     }
 
     // Finalize javadoc
-    report::debug("  - Finalizing javadoc");
-    JavadocFinalizer finalizer(*this);
-    finalizer.build();
+    {
+        report::debug("  - Finalizing javadoc");
+        JavadocFinalizer finalizer(*this);
+        finalizer.build();
+    }
 }
 
 } // clang::mrdocs

--- a/test-files/golden-tests/config/sort-members-by/sort-members-by-location.adoc
+++ b/test-files/golden-tests/config/sort-members-by/sort-members-by-location.adoc
@@ -1,0 +1,285 @@
+= Reference
+:mrdocs:
+
+[#index]
+== Global namespace
+
+=== Types
+
+[cols=1]
+|===
+| Name
+| link:#Z[`Z`] 
+|===
+
+[#Z]
+== Z
+
+=== Synopsis
+
+Declared in `&lt;sort&hyphen;members&hyphen;by&hyphen;location&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+struct Z;
+----
+
+=== Member Functions
+
+[cols=2]
+|===
+| Name
+| Description
+| link:#Z-2constructor-00[`Z`]         [.small]#[constructor]#
+| Constructors
+| link:#Z-2destructor[`&#126;Z`] [.small]#[destructor]#
+| Destructor
+| link:#Z-foo[`foo`] 
+| 
+| link:#Z-bar[`bar`] 
+| 
+| link:#Z-2conversion[`operator bool`] 
+| Conversion to `bool`
+| link:#Z-operator_not[`operator!`] 
+| Negation operator
+| link:#Z-operator_eq[`operator&equals;&equals;`] 
+| Equality operator
+| link:#Z-operator_not_eq[`operator!&equals;`] 
+| Inequality operator
+| link:#Z-operator_3way[`operator&lt;&equals;&gt;`] 
+| Three&hyphen;way comparison operator
+|===
+
+[#Z-2constructor-00]
+== link:#Z[Z]::Z
+
+Constructors
+
+=== Synopses
+
+Declared in `&lt;sort&hyphen;members&hyphen;by&hyphen;location&period;cpp&gt;`
+
+Construct from `int`
+
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+link:#Z-2constructor-06[Z](int value);
+----
+
+[.small]#link:#Z-2constructor-06[_» more&period;&period;&period;_]#
+
+Default constructor
+
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+link:#Z-2constructor-05[Z]();
+----
+
+[.small]#link:#Z-2constructor-05[_» more&period;&period;&period;_]#
+
+[#Z-2constructor-06]
+== link:#Z[Z]::Z
+
+Construct from `int`
+
+=== Synopsis
+
+Declared in `&lt;sort&hyphen;members&hyphen;by&hyphen;location&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+Z(int value);
+----
+
+=== Parameters
+
+[cols=2]
+|===
+| Name
+| Description
+| *value*
+| The value to construct from
+|===
+
+[#Z-2constructor-05]
+== link:#Z[Z]::Z
+
+Default constructor
+
+=== Synopsis
+
+Declared in `&lt;sort&hyphen;members&hyphen;by&hyphen;location&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+Z();
+----
+
+[#Z-2destructor]
+== link:#Z[Z]::&#126;Z
+
+Destructor
+
+=== Synopsis
+
+Declared in `&lt;sort&hyphen;members&hyphen;by&hyphen;location&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+&#126;Z();
+----
+
+[#Z-foo]
+== link:#Z[Z]::foo
+
+=== Synopsis
+
+Declared in `&lt;sort&hyphen;members&hyphen;by&hyphen;location&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+void
+foo() const;
+----
+
+[#Z-bar]
+== link:#Z[Z]::bar
+
+=== Synopsis
+
+Declared in `&lt;sort&hyphen;members&hyphen;by&hyphen;location&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+void
+bar() const;
+----
+
+[#Z-2conversion]
+== link:#Z[Z]::operator bool
+
+Conversion to `bool`
+
+=== Synopsis
+
+Declared in `&lt;sort&hyphen;members&hyphen;by&hyphen;location&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+operator bool() const;
+----
+
+=== Return Value
+
+The object converted to `bool`
+
+[#Z-operator_not]
+== link:#Z[Z]::operator!
+
+Negation operator
+
+=== Synopsis
+
+Declared in `&lt;sort&hyphen;members&hyphen;by&hyphen;location&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+bool
+operator!() const;
+----
+
+=== Return Value
+
+`true` if the object is falsy, `false` otherwise
+
+[#Z-operator_eq]
+== link:#Z[Z]::operator&equals;&equals;
+
+Equality operator
+
+=== Synopsis
+
+Declared in `&lt;sort&hyphen;members&hyphen;by&hyphen;location&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+bool
+operator&equals;&equals;(link:#Z[Z] const& rhs) const;
+----
+
+=== Return Value
+
+`true` if the objects are equal, `false` otherwise
+
+=== Parameters
+
+[cols=2]
+|===
+| Name
+| Description
+| *rhs*
+| The right operand
+|===
+
+[#Z-operator_not_eq]
+== link:#Z[Z]::operator!&equals;
+
+Inequality operator
+
+=== Synopsis
+
+Declared in `&lt;sort&hyphen;members&hyphen;by&hyphen;location&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+bool
+operator!&equals;(link:#Z[Z] const& rhs) const;
+----
+
+=== Return Value
+
+`true` if the objects are not equal, `false` otherwise
+
+=== Parameters
+
+[cols=2]
+|===
+| Name
+| Description
+| *rhs*
+| The right operand
+|===
+
+[#Z-operator_3way]
+== link:#Z[Z]::operator&lt;&equals;&gt;
+
+Three&hyphen;way comparison operator
+
+=== Synopsis
+
+Declared in `&lt;sort&hyphen;members&hyphen;by&hyphen;location&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+auto
+operator&lt;&equals;&gt;(link:#Z[Z] const& rhs) const;
+----
+
+=== Return Value
+
+The relative order of the objects
+
+=== Parameters
+
+[cols=2]
+|===
+| Name
+| Description
+| *rhs*
+| The right operand
+|===
+
+
+[.small]#Created with https://www.mrdocs.com[MrDocs]#

--- a/test-files/golden-tests/config/sort-members-by/sort-members-by-location.cpp
+++ b/test-files/golden-tests/config/sort-members-by/sort-members-by-location.cpp
@@ -1,0 +1,13 @@
+struct Z {
+    auto operator<=>(Z const&) const;
+    bool operator!=(Z const&) const;
+    bool operator==(Z const&) const;
+    bool operator!() const;
+    operator bool() const;
+    void foo() const;
+    void bar() const;
+    ~Z();
+    Z(int);
+    Z();
+};
+

--- a/test-files/golden-tests/config/sort-members-by/sort-members-by-location.html
+++ b/test-files/golden-tests/config/sort-members-by/sort-members-by-location.html
@@ -1,0 +1,376 @@
+<html lang="en">
+<head>
+<title>Reference</title>
+</head>
+<body>
+<div>
+<h1>Reference</h1>
+<div>
+<div>
+<h2 id="index"><a href="#index"></a></h2>
+</div>
+<h2>Types</h2>
+<table style="table-layout: fixed; width: 100%;">
+<thead>
+<tr>
+<th>Name</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a href="#Z"><code>Z</code></a> </td></tr>
+</tbody>
+</table>
+
+</div>
+<div>
+<div>
+<h2 id="Z"><a href="#Z">Z</a></h2>
+</div>
+<div>
+<h3>Synopsis</h3>
+<div>
+Declared in <code>&lt;sort-members-by-location.cpp&gt;</code></div>
+<pre>
+<code class="source-code cpp">struct Z;
+
+</code>
+</pre>
+</div>
+<h2>Member Functions</h2>
+<table style="table-layout: fixed; width: 100%;">
+<thead>
+<tr>
+<th>Name</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a href="#Z-2constructor-00"><code>Z</code></a>         <span class="small">[constructor]</span></td><td><span>Constructors</span></td></tr><tr>
+<td><a href="#Z-2destructor"><code>~Z</code></a> <span class="small">[destructor]</span></td><td><span>Destructor</span></td></tr><tr>
+<td><a href="#Z-foo"><code>foo</code></a> </td><td><span></span></td></tr><tr>
+<td><a href="#Z-bar"><code>bar</code></a> </td><td><span></span></td></tr><tr>
+<td><a href="#Z-2conversion"><code>operator bool</code></a> </td><td><span>Conversion to <code>bool</code></span></td></tr><tr>
+<td><a href="#Z-operator_not"><code>operator!</code></a> </td><td><span>Negation operator</span></td></tr><tr>
+<td><a href="#Z-operator_eq"><code>operator&#x3D;&#x3D;</code></a> </td><td><span>Equality operator</span></td></tr><tr>
+<td><a href="#Z-operator_not_eq"><code>operator!&#x3D;</code></a> </td><td><span>Inequality operator</span></td></tr><tr>
+<td><a href="#Z-operator_3way"><code>operator&lt;&#x3D;&gt;</code></a> </td><td><span>Three-way comparison operator</span></td></tr>
+</tbody>
+</table>
+
+
+
+</div>
+<div>
+<div>
+<h2 id="Z-2constructor-00"><a href="#Z-2constructor-00">Z::Z</a></h2>
+<div>
+<span>Constructors</span>
+
+</div>
+</div>
+<div>
+<h3>Synopses</h3>
+<div>
+Declared in <code>&lt;sort-members-by-location.cpp&gt;</code></div>
+<span>Construct from <code>int</code></span>
+<pre>
+<code class="source-code cpp"><a href="#Z-2constructor-06">Z</a>(int value);
+
+</code>
+</pre><span class="small"><a href="#Z-2constructor-06"><em>» more...</em></a></span>
+
+<span>Default constructor</span>
+<pre>
+<code class="source-code cpp"><a href="#Z-2constructor-05">Z</a>();
+
+</code>
+</pre><span class="small"><a href="#Z-2constructor-05"><em>» more...</em></a></span>
+
+
+</div>
+</div>
+<div>
+<div>
+<h2 id="Z-2constructor-06"><a href="#Z-2constructor-06">Z::Z</a></h2>
+<div>
+<span>Construct from <code>int</code></span>
+
+</div>
+</div>
+<div>
+<h3>Synopsis</h3>
+<div>
+Declared in <code>&lt;sort-members-by-location.cpp&gt;</code></div>
+<pre>
+<code class="source-code cpp">Z(int value);
+
+</code>
+</pre>
+</div>
+<div>
+<h3>Parameters</h3>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>value</strong></td>
+<td><span>The value to construct from</span></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div>
+<div>
+<h2 id="Z-2constructor-05"><a href="#Z-2constructor-05">Z::Z</a></h2>
+<div>
+<span>Default constructor</span>
+
+</div>
+</div>
+<div>
+<h3>Synopsis</h3>
+<div>
+Declared in <code>&lt;sort-members-by-location.cpp&gt;</code></div>
+<pre>
+<code class="source-code cpp">Z();
+
+</code>
+</pre>
+</div>
+</div>
+<div>
+<div>
+<h2 id="Z-2destructor"><a href="#Z-2destructor">Z::~Z</a></h2>
+<div>
+<span>Destructor</span>
+
+</div>
+</div>
+<div>
+<h3>Synopsis</h3>
+<div>
+Declared in <code>&lt;sort-members-by-location.cpp&gt;</code></div>
+<pre>
+<code class="source-code cpp">~Z();
+
+</code>
+</pre>
+</div>
+</div>
+<div>
+<div>
+<h2 id="Z-foo"><a href="#Z-foo">Z::foo</a></h2>
+</div>
+<div>
+<h3>Synopsis</h3>
+<div>
+Declared in <code>&lt;sort-members-by-location.cpp&gt;</code></div>
+<pre>
+<code class="source-code cpp">void
+foo() const;
+
+</code>
+</pre>
+</div>
+</div>
+<div>
+<div>
+<h2 id="Z-bar"><a href="#Z-bar">Z::bar</a></h2>
+</div>
+<div>
+<h3>Synopsis</h3>
+<div>
+Declared in <code>&lt;sort-members-by-location.cpp&gt;</code></div>
+<pre>
+<code class="source-code cpp">void
+bar() const;
+
+</code>
+</pre>
+</div>
+</div>
+<div>
+<div>
+<h2 id="Z-2conversion"><a href="#Z-2conversion">Z::operator bool</a></h2>
+<div>
+<span>Conversion to <code>bool</code></span>
+
+</div>
+</div>
+<div>
+<h3>Synopsis</h3>
+<div>
+Declared in <code>&lt;sort-members-by-location.cpp&gt;</code></div>
+<pre>
+<code class="source-code cpp">operator bool() const;
+
+</code>
+</pre>
+</div>
+<div>
+<h3>Return Value</h3>
+<span>The object converted to <code>bool</code></span>
+</div>
+</div>
+<div>
+<div>
+<h2 id="Z-operator_not"><a href="#Z-operator_not">Z::operator!</a></h2>
+<div>
+<span>Negation operator</span>
+
+</div>
+</div>
+<div>
+<h3>Synopsis</h3>
+<div>
+Declared in <code>&lt;sort-members-by-location.cpp&gt;</code></div>
+<pre>
+<code class="source-code cpp">bool
+operator!() const;
+
+</code>
+</pre>
+</div>
+<div>
+<h3>Return Value</h3>
+<span><code>true</code> if the object is falsy, <code>false</code> otherwise</span>
+</div>
+</div>
+<div>
+<div>
+<h2 id="Z-operator_eq"><a href="#Z-operator_eq">Z::operator&#x3D;&#x3D;</a></h2>
+<div>
+<span>Equality operator</span>
+
+</div>
+</div>
+<div>
+<h3>Synopsis</h3>
+<div>
+Declared in <code>&lt;sort-members-by-location.cpp&gt;</code></div>
+<pre>
+<code class="source-code cpp">bool
+operator&#x3D;&#x3D;(<a href="#Z">Z</a> const& rhs) const;
+
+</code>
+</pre>
+</div>
+<div>
+<h3>Return Value</h3>
+<span><code>true</code> if the objects are equal, <code>false</code> otherwise</span>
+</div>
+<div>
+<h3>Parameters</h3>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>rhs</strong></td>
+<td><span>The right operand</span></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div>
+<div>
+<h2 id="Z-operator_not_eq"><a href="#Z-operator_not_eq">Z::operator!&#x3D;</a></h2>
+<div>
+<span>Inequality operator</span>
+
+</div>
+</div>
+<div>
+<h3>Synopsis</h3>
+<div>
+Declared in <code>&lt;sort-members-by-location.cpp&gt;</code></div>
+<pre>
+<code class="source-code cpp">bool
+operator!&#x3D;(<a href="#Z">Z</a> const& rhs) const;
+
+</code>
+</pre>
+</div>
+<div>
+<h3>Return Value</h3>
+<span><code>true</code> if the objects are not equal, <code>false</code> otherwise</span>
+</div>
+<div>
+<h3>Parameters</h3>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>rhs</strong></td>
+<td><span>The right operand</span></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div>
+<div>
+<h2 id="Z-operator_3way"><a href="#Z-operator_3way">Z::operator&lt;&#x3D;&gt;</a></h2>
+<div>
+<span>Three-way comparison operator</span>
+
+</div>
+</div>
+<div>
+<h3>Synopsis</h3>
+<div>
+Declared in <code>&lt;sort-members-by-location.cpp&gt;</code></div>
+<pre>
+<code class="source-code cpp">auto
+operator&lt;&#x3D;&gt;(<a href="#Z">Z</a> const& rhs) const;
+
+</code>
+</pre>
+</div>
+<div>
+<h3>Return Value</h3>
+<span>The relative order of the objects</span>
+</div>
+<div>
+<h3>Parameters</h3>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>rhs</strong></td>
+<td><span>The right operand</span></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+
+</div>
+<div>
+<h4>Created with <a href="https://www.mrdocs.com">MrDocs</a></h4>
+</div>
+</body>
+</html>

--- a/test-files/golden-tests/config/sort-members-by/sort-members-by-location.xml
+++ b/test-files/golden-tests/config/sort-members-by/sort-members-by-location.xml
@@ -1,0 +1,163 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mrdocs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="https://github.com/cppalliance/mrdocs/raw/develop/mrdocs.rnc">
+<namespace id="//////////////////////////8=">
+  <struct name="Z" id="NQ8uQgTcafPcttyBMHHLHAXA4MA=">
+    <file short-path="sort-members-by-location.cpp" source-path="sort-members-by-location.cpp" line="1" class="def"/>
+    <function class="constructor" name="Z" id="aQWtFVa4Xa+eceLXiLW74q44JRk=">
+      <file short-path="sort-members-by-location.cpp" source-path="sort-members-by-location.cpp" line="10"/>
+      <param name="value">
+        <type name="int"/>
+      </param>
+      <doc>
+        <brief>
+          <text>Construct from </text>
+          <mono>int</mono>
+        </brief>
+        <param name="value">
+          <text>The value to construct from</text>
+        </param>
+      </doc>
+    </function>
+    <function class="constructor" name="Z" id="WltomC+2IcmzMN0COGL0OWWmbZk=">
+      <file short-path="sort-members-by-location.cpp" source-path="sort-members-by-location.cpp" line="11"/>
+      <doc>
+        <brief>
+          <text>Default constructor</text>
+        </brief>
+      </doc>
+    </function>
+    <function class="destructor" name="~Z" id="HMG56OCQ5OpB2E9hu4bG3/hoOho=">
+      <file short-path="sort-members-by-location.cpp" source-path="sort-members-by-location.cpp" line="9"/>
+      <doc>
+        <brief>
+          <text>Destructor</text>
+        </brief>
+      </doc>
+    </function>
+    <function name="foo" id="lBA1besl9J3wAZAcEn9C+K05hf4=">
+      <file short-path="sort-members-by-location.cpp" source-path="sort-members-by-location.cpp" line="7"/>
+      <attr id="is-const"/>
+    </function>
+    <function name="bar" id="gRx0djRTyQ5zuzBd9ujP7LLlWNg=">
+      <file short-path="sort-members-by-location.cpp" source-path="sort-members-by-location.cpp" line="8"/>
+      <attr id="is-const"/>
+    </function>
+    <function class="conversion" name="operator bool" id="zQ0DYAZMF+xhfbo8hUyqZRNKJ+U=">
+      <file short-path="sort-members-by-location.cpp" source-path="sort-members-by-location.cpp" line="6"/>
+      <attr id="is-const"/>
+      <return>
+        <type name="bool"/>
+      </return>
+      <doc>
+        <brief>
+          <text>Conversion to </text>
+          <mono>bool</mono>
+        </brief>
+        <returns>
+          <text>The object converted to </text>
+          <mono>bool</mono>
+        </returns>
+      </doc>
+    </function>
+    <function name="operator!" id="rjPdhFxUkaC43tWXi+kka78JQxI=">
+      <file short-path="sort-members-by-location.cpp" source-path="sort-members-by-location.cpp" line="5"/>
+      <attr id="operator" name="not" value="27"/>
+      <attr id="is-const"/>
+      <return>
+        <type name="bool"/>
+      </return>
+      <doc>
+        <brief>
+          <text>Negation operator</text>
+        </brief>
+        <returns>
+          <mono>true</mono>
+          <text> if the object is falsy, </text>
+          <mono>false</mono>
+          <text> otherwise</text>
+        </returns>
+      </doc>
+    </function>
+    <function name="operator==" id="atwUGLD+QHVhH3x1+8qzINNxzMY=">
+      <file short-path="sort-members-by-location.cpp" source-path="sort-members-by-location.cpp" line="4"/>
+      <attr id="operator" name="eq" value="28"/>
+      <attr id="is-const"/>
+      <return>
+        <type name="bool"/>
+      </return>
+      <param name="rhs">
+        <type class="lvalue-reference">
+          <pointee-type id="NQ8uQgTcafPcttyBMHHLHAXA4MA=" name="Z" cv-qualifiers="const"/>
+        </type>
+      </param>
+      <doc>
+        <brief>
+          <text>Equality operator</text>
+        </brief>
+        <returns>
+          <mono>true</mono>
+          <text> if the objects are equal, </text>
+          <mono>false</mono>
+          <text> otherwise</text>
+        </returns>
+        <param name="rhs">
+          <text>The right operand</text>
+        </param>
+      </doc>
+    </function>
+    <function name="operator!=" id="CB0pXrzU8BKZ2LF0BSpclxIfgrs=">
+      <file short-path="sort-members-by-location.cpp" source-path="sort-members-by-location.cpp" line="3"/>
+      <attr id="operator" name="not_eq" value="29"/>
+      <attr id="is-const"/>
+      <return>
+        <type name="bool"/>
+      </return>
+      <param name="rhs">
+        <type class="lvalue-reference">
+          <pointee-type id="NQ8uQgTcafPcttyBMHHLHAXA4MA=" name="Z" cv-qualifiers="const"/>
+        </type>
+      </param>
+      <doc>
+        <brief>
+          <text>Inequality operator</text>
+        </brief>
+        <returns>
+          <mono>true</mono>
+          <text> if the objects are not equal, </text>
+          <mono>false</mono>
+          <text> otherwise</text>
+        </returns>
+        <param name="rhs">
+          <text>The right operand</text>
+        </param>
+      </doc>
+    </function>
+    <function name="operator&lt;=&gt;" id="6/NYLeQdPqWrbu5kHnTpE3u6Yg4=">
+      <file short-path="sort-members-by-location.cpp" source-path="sort-members-by-location.cpp" line="2"/>
+      <attr id="operator" name="3way" value="34"/>
+      <attr id="is-const"/>
+      <return>
+        <type class="auto" keyword="auto">
+        </type>
+      </return>
+      <param name="rhs">
+        <type class="lvalue-reference">
+          <pointee-type id="NQ8uQgTcafPcttyBMHHLHAXA4MA=" name="Z" cv-qualifiers="const"/>
+        </type>
+      </param>
+      <doc>
+        <brief>
+          <text>Three-way comparison operator</text>
+        </brief>
+        <returns>
+          <text>The relative order of the objects</text>
+        </returns>
+        <param name="rhs">
+          <text>The right operand</text>
+        </param>
+      </doc>
+    </function>
+  </struct>
+</namespace>
+</mrdocs>

--- a/test-files/golden-tests/config/sort-members-by/sort-members-by-location.yml
+++ b/test-files/golden-tests/config/sort-members-by/sort-members-by-location.yml
@@ -1,0 +1,2 @@
+sort-members: true
+sort-members-by: location

--- a/test-files/golden-tests/config/sort-members-by/sort-members-by-name.adoc
+++ b/test-files/golden-tests/config/sort-members-by/sort-members-by-name.adoc
@@ -1,0 +1,285 @@
+= Reference
+:mrdocs:
+
+[#index]
+== Global namespace
+
+=== Types
+
+[cols=1]
+|===
+| Name
+| link:#Z[`Z`] 
+|===
+
+[#Z]
+== Z
+
+=== Synopsis
+
+Declared in `&lt;sort&hyphen;members&hyphen;by&hyphen;name&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+struct Z;
+----
+
+=== Member Functions
+
+[cols=2]
+|===
+| Name
+| Description
+| link:#Z-2constructor-00[`Z`]         [.small]#[constructor]#
+| Constructors
+| link:#Z-2destructor[`&#126;Z`] [.small]#[destructor]#
+| Destructor
+| link:#Z-bar[`bar`] 
+| 
+| link:#Z-foo[`foo`] 
+| 
+| link:#Z-2conversion[`operator bool`] 
+| Conversion to `bool`
+| link:#Z-operator_not[`operator!`] 
+| Negation operator
+| link:#Z-operator_eq[`operator&equals;&equals;`] 
+| Equality operator
+| link:#Z-operator_not_eq[`operator!&equals;`] 
+| Inequality operator
+| link:#Z-operator_3way[`operator&lt;&equals;&gt;`] 
+| Three&hyphen;way comparison operator
+|===
+
+[#Z-2constructor-00]
+== link:#Z[Z]::Z
+
+Constructors
+
+=== Synopses
+
+Declared in `&lt;sort&hyphen;members&hyphen;by&hyphen;name&period;cpp&gt;`
+
+Default constructor
+
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+link:#Z-2constructor-05[Z]();
+----
+
+[.small]#link:#Z-2constructor-05[_» more&period;&period;&period;_]#
+
+Construct from `int`
+
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+link:#Z-2constructor-06[Z](int value);
+----
+
+[.small]#link:#Z-2constructor-06[_» more&period;&period;&period;_]#
+
+[#Z-2constructor-05]
+== link:#Z[Z]::Z
+
+Default constructor
+
+=== Synopsis
+
+Declared in `&lt;sort&hyphen;members&hyphen;by&hyphen;name&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+Z();
+----
+
+[#Z-2constructor-06]
+== link:#Z[Z]::Z
+
+Construct from `int`
+
+=== Synopsis
+
+Declared in `&lt;sort&hyphen;members&hyphen;by&hyphen;name&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+Z(int value);
+----
+
+=== Parameters
+
+[cols=2]
+|===
+| Name
+| Description
+| *value*
+| The value to construct from
+|===
+
+[#Z-2destructor]
+== link:#Z[Z]::&#126;Z
+
+Destructor
+
+=== Synopsis
+
+Declared in `&lt;sort&hyphen;members&hyphen;by&hyphen;name&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+&#126;Z();
+----
+
+[#Z-bar]
+== link:#Z[Z]::bar
+
+=== Synopsis
+
+Declared in `&lt;sort&hyphen;members&hyphen;by&hyphen;name&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+void
+bar() const;
+----
+
+[#Z-foo]
+== link:#Z[Z]::foo
+
+=== Synopsis
+
+Declared in `&lt;sort&hyphen;members&hyphen;by&hyphen;name&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+void
+foo() const;
+----
+
+[#Z-2conversion]
+== link:#Z[Z]::operator bool
+
+Conversion to `bool`
+
+=== Synopsis
+
+Declared in `&lt;sort&hyphen;members&hyphen;by&hyphen;name&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+operator bool() const;
+----
+
+=== Return Value
+
+The object converted to `bool`
+
+[#Z-operator_not]
+== link:#Z[Z]::operator!
+
+Negation operator
+
+=== Synopsis
+
+Declared in `&lt;sort&hyphen;members&hyphen;by&hyphen;name&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+bool
+operator!() const;
+----
+
+=== Return Value
+
+`true` if the object is falsy, `false` otherwise
+
+[#Z-operator_eq]
+== link:#Z[Z]::operator&equals;&equals;
+
+Equality operator
+
+=== Synopsis
+
+Declared in `&lt;sort&hyphen;members&hyphen;by&hyphen;name&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+bool
+operator&equals;&equals;(link:#Z[Z] const& rhs) const;
+----
+
+=== Return Value
+
+`true` if the objects are equal, `false` otherwise
+
+=== Parameters
+
+[cols=2]
+|===
+| Name
+| Description
+| *rhs*
+| The right operand
+|===
+
+[#Z-operator_not_eq]
+== link:#Z[Z]::operator!&equals;
+
+Inequality operator
+
+=== Synopsis
+
+Declared in `&lt;sort&hyphen;members&hyphen;by&hyphen;name&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+bool
+operator!&equals;(link:#Z[Z] const& rhs) const;
+----
+
+=== Return Value
+
+`true` if the objects are not equal, `false` otherwise
+
+=== Parameters
+
+[cols=2]
+|===
+| Name
+| Description
+| *rhs*
+| The right operand
+|===
+
+[#Z-operator_3way]
+== link:#Z[Z]::operator&lt;&equals;&gt;
+
+Three&hyphen;way comparison operator
+
+=== Synopsis
+
+Declared in `&lt;sort&hyphen;members&hyphen;by&hyphen;name&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+auto
+operator&lt;&equals;&gt;(link:#Z[Z] const& rhs) const;
+----
+
+=== Return Value
+
+The relative order of the objects
+
+=== Parameters
+
+[cols=2]
+|===
+| Name
+| Description
+| *rhs*
+| The right operand
+|===
+
+
+[.small]#Created with https://www.mrdocs.com[MrDocs]#

--- a/test-files/golden-tests/config/sort-members-by/sort-members-by-name.cpp
+++ b/test-files/golden-tests/config/sort-members-by/sort-members-by-name.cpp
@@ -1,0 +1,13 @@
+struct Z {
+    auto operator<=>(Z const&) const;
+    bool operator!=(Z const&) const;
+    bool operator==(Z const&) const;
+    bool operator!() const;
+    operator bool() const;
+    void foo() const;
+    void bar() const;
+    ~Z();
+    Z(int);
+    Z();
+};
+

--- a/test-files/golden-tests/config/sort-members-by/sort-members-by-name.html
+++ b/test-files/golden-tests/config/sort-members-by/sort-members-by-name.html
@@ -1,0 +1,376 @@
+<html lang="en">
+<head>
+<title>Reference</title>
+</head>
+<body>
+<div>
+<h1>Reference</h1>
+<div>
+<div>
+<h2 id="index"><a href="#index"></a></h2>
+</div>
+<h2>Types</h2>
+<table style="table-layout: fixed; width: 100%;">
+<thead>
+<tr>
+<th>Name</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a href="#Z"><code>Z</code></a> </td></tr>
+</tbody>
+</table>
+
+</div>
+<div>
+<div>
+<h2 id="Z"><a href="#Z">Z</a></h2>
+</div>
+<div>
+<h3>Synopsis</h3>
+<div>
+Declared in <code>&lt;sort-members-by-name.cpp&gt;</code></div>
+<pre>
+<code class="source-code cpp">struct Z;
+
+</code>
+</pre>
+</div>
+<h2>Member Functions</h2>
+<table style="table-layout: fixed; width: 100%;">
+<thead>
+<tr>
+<th>Name</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a href="#Z-2constructor-00"><code>Z</code></a>         <span class="small">[constructor]</span></td><td><span>Constructors</span></td></tr><tr>
+<td><a href="#Z-2destructor"><code>~Z</code></a> <span class="small">[destructor]</span></td><td><span>Destructor</span></td></tr><tr>
+<td><a href="#Z-bar"><code>bar</code></a> </td><td><span></span></td></tr><tr>
+<td><a href="#Z-foo"><code>foo</code></a> </td><td><span></span></td></tr><tr>
+<td><a href="#Z-2conversion"><code>operator bool</code></a> </td><td><span>Conversion to <code>bool</code></span></td></tr><tr>
+<td><a href="#Z-operator_not"><code>operator!</code></a> </td><td><span>Negation operator</span></td></tr><tr>
+<td><a href="#Z-operator_eq"><code>operator&#x3D;&#x3D;</code></a> </td><td><span>Equality operator</span></td></tr><tr>
+<td><a href="#Z-operator_not_eq"><code>operator!&#x3D;</code></a> </td><td><span>Inequality operator</span></td></tr><tr>
+<td><a href="#Z-operator_3way"><code>operator&lt;&#x3D;&gt;</code></a> </td><td><span>Three-way comparison operator</span></td></tr>
+</tbody>
+</table>
+
+
+
+</div>
+<div>
+<div>
+<h2 id="Z-2constructor-00"><a href="#Z-2constructor-00">Z::Z</a></h2>
+<div>
+<span>Constructors</span>
+
+</div>
+</div>
+<div>
+<h3>Synopses</h3>
+<div>
+Declared in <code>&lt;sort-members-by-name.cpp&gt;</code></div>
+<span>Default constructor</span>
+<pre>
+<code class="source-code cpp"><a href="#Z-2constructor-05">Z</a>();
+
+</code>
+</pre><span class="small"><a href="#Z-2constructor-05"><em>» more...</em></a></span>
+
+<span>Construct from <code>int</code></span>
+<pre>
+<code class="source-code cpp"><a href="#Z-2constructor-06">Z</a>(int value);
+
+</code>
+</pre><span class="small"><a href="#Z-2constructor-06"><em>» more...</em></a></span>
+
+
+</div>
+</div>
+<div>
+<div>
+<h2 id="Z-2constructor-05"><a href="#Z-2constructor-05">Z::Z</a></h2>
+<div>
+<span>Default constructor</span>
+
+</div>
+</div>
+<div>
+<h3>Synopsis</h3>
+<div>
+Declared in <code>&lt;sort-members-by-name.cpp&gt;</code></div>
+<pre>
+<code class="source-code cpp">Z();
+
+</code>
+</pre>
+</div>
+</div>
+<div>
+<div>
+<h2 id="Z-2constructor-06"><a href="#Z-2constructor-06">Z::Z</a></h2>
+<div>
+<span>Construct from <code>int</code></span>
+
+</div>
+</div>
+<div>
+<h3>Synopsis</h3>
+<div>
+Declared in <code>&lt;sort-members-by-name.cpp&gt;</code></div>
+<pre>
+<code class="source-code cpp">Z(int value);
+
+</code>
+</pre>
+</div>
+<div>
+<h3>Parameters</h3>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>value</strong></td>
+<td><span>The value to construct from</span></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div>
+<div>
+<h2 id="Z-2destructor"><a href="#Z-2destructor">Z::~Z</a></h2>
+<div>
+<span>Destructor</span>
+
+</div>
+</div>
+<div>
+<h3>Synopsis</h3>
+<div>
+Declared in <code>&lt;sort-members-by-name.cpp&gt;</code></div>
+<pre>
+<code class="source-code cpp">~Z();
+
+</code>
+</pre>
+</div>
+</div>
+<div>
+<div>
+<h2 id="Z-bar"><a href="#Z-bar">Z::bar</a></h2>
+</div>
+<div>
+<h3>Synopsis</h3>
+<div>
+Declared in <code>&lt;sort-members-by-name.cpp&gt;</code></div>
+<pre>
+<code class="source-code cpp">void
+bar() const;
+
+</code>
+</pre>
+</div>
+</div>
+<div>
+<div>
+<h2 id="Z-foo"><a href="#Z-foo">Z::foo</a></h2>
+</div>
+<div>
+<h3>Synopsis</h3>
+<div>
+Declared in <code>&lt;sort-members-by-name.cpp&gt;</code></div>
+<pre>
+<code class="source-code cpp">void
+foo() const;
+
+</code>
+</pre>
+</div>
+</div>
+<div>
+<div>
+<h2 id="Z-2conversion"><a href="#Z-2conversion">Z::operator bool</a></h2>
+<div>
+<span>Conversion to <code>bool</code></span>
+
+</div>
+</div>
+<div>
+<h3>Synopsis</h3>
+<div>
+Declared in <code>&lt;sort-members-by-name.cpp&gt;</code></div>
+<pre>
+<code class="source-code cpp">operator bool() const;
+
+</code>
+</pre>
+</div>
+<div>
+<h3>Return Value</h3>
+<span>The object converted to <code>bool</code></span>
+</div>
+</div>
+<div>
+<div>
+<h2 id="Z-operator_not"><a href="#Z-operator_not">Z::operator!</a></h2>
+<div>
+<span>Negation operator</span>
+
+</div>
+</div>
+<div>
+<h3>Synopsis</h3>
+<div>
+Declared in <code>&lt;sort-members-by-name.cpp&gt;</code></div>
+<pre>
+<code class="source-code cpp">bool
+operator!() const;
+
+</code>
+</pre>
+</div>
+<div>
+<h3>Return Value</h3>
+<span><code>true</code> if the object is falsy, <code>false</code> otherwise</span>
+</div>
+</div>
+<div>
+<div>
+<h2 id="Z-operator_eq"><a href="#Z-operator_eq">Z::operator&#x3D;&#x3D;</a></h2>
+<div>
+<span>Equality operator</span>
+
+</div>
+</div>
+<div>
+<h3>Synopsis</h3>
+<div>
+Declared in <code>&lt;sort-members-by-name.cpp&gt;</code></div>
+<pre>
+<code class="source-code cpp">bool
+operator&#x3D;&#x3D;(<a href="#Z">Z</a> const& rhs) const;
+
+</code>
+</pre>
+</div>
+<div>
+<h3>Return Value</h3>
+<span><code>true</code> if the objects are equal, <code>false</code> otherwise</span>
+</div>
+<div>
+<h3>Parameters</h3>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>rhs</strong></td>
+<td><span>The right operand</span></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div>
+<div>
+<h2 id="Z-operator_not_eq"><a href="#Z-operator_not_eq">Z::operator!&#x3D;</a></h2>
+<div>
+<span>Inequality operator</span>
+
+</div>
+</div>
+<div>
+<h3>Synopsis</h3>
+<div>
+Declared in <code>&lt;sort-members-by-name.cpp&gt;</code></div>
+<pre>
+<code class="source-code cpp">bool
+operator!&#x3D;(<a href="#Z">Z</a> const& rhs) const;
+
+</code>
+</pre>
+</div>
+<div>
+<h3>Return Value</h3>
+<span><code>true</code> if the objects are not equal, <code>false</code> otherwise</span>
+</div>
+<div>
+<h3>Parameters</h3>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>rhs</strong></td>
+<td><span>The right operand</span></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div>
+<div>
+<h2 id="Z-operator_3way"><a href="#Z-operator_3way">Z::operator&lt;&#x3D;&gt;</a></h2>
+<div>
+<span>Three-way comparison operator</span>
+
+</div>
+</div>
+<div>
+<h3>Synopsis</h3>
+<div>
+Declared in <code>&lt;sort-members-by-name.cpp&gt;</code></div>
+<pre>
+<code class="source-code cpp">auto
+operator&lt;&#x3D;&gt;(<a href="#Z">Z</a> const& rhs) const;
+
+</code>
+</pre>
+</div>
+<div>
+<h3>Return Value</h3>
+<span>The relative order of the objects</span>
+</div>
+<div>
+<h3>Parameters</h3>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>rhs</strong></td>
+<td><span>The right operand</span></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+
+</div>
+<div>
+<h4>Created with <a href="https://www.mrdocs.com">MrDocs</a></h4>
+</div>
+</body>
+</html>

--- a/test-files/golden-tests/config/sort-members-by/sort-members-by-name.xml
+++ b/test-files/golden-tests/config/sort-members-by/sort-members-by-name.xml
@@ -1,0 +1,163 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mrdocs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="https://github.com/cppalliance/mrdocs/raw/develop/mrdocs.rnc">
+<namespace id="//////////////////////////8=">
+  <struct name="Z" id="NQ8uQgTcafPcttyBMHHLHAXA4MA=">
+    <file short-path="sort-members-by-name.cpp" source-path="sort-members-by-name.cpp" line="1" class="def"/>
+    <function class="constructor" name="Z" id="WltomC+2IcmzMN0COGL0OWWmbZk=">
+      <file short-path="sort-members-by-name.cpp" source-path="sort-members-by-name.cpp" line="11"/>
+      <doc>
+        <brief>
+          <text>Default constructor</text>
+        </brief>
+      </doc>
+    </function>
+    <function class="constructor" name="Z" id="aQWtFVa4Xa+eceLXiLW74q44JRk=">
+      <file short-path="sort-members-by-name.cpp" source-path="sort-members-by-name.cpp" line="10"/>
+      <param name="value">
+        <type name="int"/>
+      </param>
+      <doc>
+        <brief>
+          <text>Construct from </text>
+          <mono>int</mono>
+        </brief>
+        <param name="value">
+          <text>The value to construct from</text>
+        </param>
+      </doc>
+    </function>
+    <function class="destructor" name="~Z" id="HMG56OCQ5OpB2E9hu4bG3/hoOho=">
+      <file short-path="sort-members-by-name.cpp" source-path="sort-members-by-name.cpp" line="9"/>
+      <doc>
+        <brief>
+          <text>Destructor</text>
+        </brief>
+      </doc>
+    </function>
+    <function name="bar" id="gRx0djRTyQ5zuzBd9ujP7LLlWNg=">
+      <file short-path="sort-members-by-name.cpp" source-path="sort-members-by-name.cpp" line="8"/>
+      <attr id="is-const"/>
+    </function>
+    <function name="foo" id="lBA1besl9J3wAZAcEn9C+K05hf4=">
+      <file short-path="sort-members-by-name.cpp" source-path="sort-members-by-name.cpp" line="7"/>
+      <attr id="is-const"/>
+    </function>
+    <function class="conversion" name="operator bool" id="zQ0DYAZMF+xhfbo8hUyqZRNKJ+U=">
+      <file short-path="sort-members-by-name.cpp" source-path="sort-members-by-name.cpp" line="6"/>
+      <attr id="is-const"/>
+      <return>
+        <type name="bool"/>
+      </return>
+      <doc>
+        <brief>
+          <text>Conversion to </text>
+          <mono>bool</mono>
+        </brief>
+        <returns>
+          <text>The object converted to </text>
+          <mono>bool</mono>
+        </returns>
+      </doc>
+    </function>
+    <function name="operator!" id="rjPdhFxUkaC43tWXi+kka78JQxI=">
+      <file short-path="sort-members-by-name.cpp" source-path="sort-members-by-name.cpp" line="5"/>
+      <attr id="operator" name="not" value="27"/>
+      <attr id="is-const"/>
+      <return>
+        <type name="bool"/>
+      </return>
+      <doc>
+        <brief>
+          <text>Negation operator</text>
+        </brief>
+        <returns>
+          <mono>true</mono>
+          <text> if the object is falsy, </text>
+          <mono>false</mono>
+          <text> otherwise</text>
+        </returns>
+      </doc>
+    </function>
+    <function name="operator==" id="atwUGLD+QHVhH3x1+8qzINNxzMY=">
+      <file short-path="sort-members-by-name.cpp" source-path="sort-members-by-name.cpp" line="4"/>
+      <attr id="operator" name="eq" value="28"/>
+      <attr id="is-const"/>
+      <return>
+        <type name="bool"/>
+      </return>
+      <param name="rhs">
+        <type class="lvalue-reference">
+          <pointee-type id="NQ8uQgTcafPcttyBMHHLHAXA4MA=" name="Z" cv-qualifiers="const"/>
+        </type>
+      </param>
+      <doc>
+        <brief>
+          <text>Equality operator</text>
+        </brief>
+        <returns>
+          <mono>true</mono>
+          <text> if the objects are equal, </text>
+          <mono>false</mono>
+          <text> otherwise</text>
+        </returns>
+        <param name="rhs">
+          <text>The right operand</text>
+        </param>
+      </doc>
+    </function>
+    <function name="operator!=" id="CB0pXrzU8BKZ2LF0BSpclxIfgrs=">
+      <file short-path="sort-members-by-name.cpp" source-path="sort-members-by-name.cpp" line="3"/>
+      <attr id="operator" name="not_eq" value="29"/>
+      <attr id="is-const"/>
+      <return>
+        <type name="bool"/>
+      </return>
+      <param name="rhs">
+        <type class="lvalue-reference">
+          <pointee-type id="NQ8uQgTcafPcttyBMHHLHAXA4MA=" name="Z" cv-qualifiers="const"/>
+        </type>
+      </param>
+      <doc>
+        <brief>
+          <text>Inequality operator</text>
+        </brief>
+        <returns>
+          <mono>true</mono>
+          <text> if the objects are not equal, </text>
+          <mono>false</mono>
+          <text> otherwise</text>
+        </returns>
+        <param name="rhs">
+          <text>The right operand</text>
+        </param>
+      </doc>
+    </function>
+    <function name="operator&lt;=&gt;" id="6/NYLeQdPqWrbu5kHnTpE3u6Yg4=">
+      <file short-path="sort-members-by-name.cpp" source-path="sort-members-by-name.cpp" line="2"/>
+      <attr id="operator" name="3way" value="34"/>
+      <attr id="is-const"/>
+      <return>
+        <type class="auto" keyword="auto">
+        </type>
+      </return>
+      <param name="rhs">
+        <type class="lvalue-reference">
+          <pointee-type id="NQ8uQgTcafPcttyBMHHLHAXA4MA=" name="Z" cv-qualifiers="const"/>
+        </type>
+      </param>
+      <doc>
+        <brief>
+          <text>Three-way comparison operator</text>
+        </brief>
+        <returns>
+          <text>The relative order of the objects</text>
+        </returns>
+        <param name="rhs">
+          <text>The right operand</text>
+        </param>
+      </doc>
+    </function>
+  </struct>
+</namespace>
+</mrdocs>

--- a/test-files/golden-tests/config/sort-members-by/sort-members-by-name.yml
+++ b/test-files/golden-tests/config/sort-members-by/sort-members-by-name.yml
@@ -1,0 +1,2 @@
+sort-members: true
+sort-members-by: name

--- a/test-files/golden-tests/config/sort-namespace-members-by/sort-namespace-members-by-location.adoc
+++ b/test-files/golden-tests/config/sort-namespace-members-by/sort-namespace-members-by-location.adoc
@@ -1,0 +1,712 @@
+= Reference
+:mrdocs:
+
+[#index]
+== Global namespace
+
+=== Types
+
+[cols=1]
+|===
+| Name
+| link:#D[`D`] 
+| link:#C-0f[`C`] 
+| link:#C-0d[`C&lt;int, char&gt;`] 
+| link:#C-03[`C&lt;int&gt;`] 
+| link:#B-0b[`B`] 
+| link:#B-04[`B&lt;int, char&gt;`] 
+| link:#B-05[`B&lt;int, U&gt;`] 
+| link:#A[`A`] 
+| link:#Z[`Z`] 
+|===
+
+=== Functions
+
+[cols=2]
+|===
+| Name
+| Description
+| link:#h[`h`] 
+| 
+| link:#g-0f[`g`] 
+| 
+| link:#f[`f`] 
+| 
+| link:#operator_not[`operator!`] 
+| Negation operator
+| link:#operator_eq[`operator&equals;&equals;`] 
+| Equality operator
+| link:#operator_not_eq[`operator!&equals;`] 
+| Inequality operator
+|===
+
+[#D]
+== D
+
+=== Synopsis
+
+Declared in `&lt;sort&hyphen;namespace&hyphen;members&hyphen;by&hyphen;location&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+struct D;
+----
+
+[#C-0f]
+== C
+
+=== Synopsis
+
+Declared in `&lt;sort&hyphen;namespace&hyphen;members&hyphen;by&hyphen;location&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+template&lt;
+    class T,
+    class U = void&gt;
+struct C;
+----
+
+[#C-0d]
+== link:#C-0f[C]&lt;int, char&gt;
+
+=== Synopsis
+
+Declared in `&lt;sort&hyphen;namespace&hyphen;members&hyphen;by&hyphen;location&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+template&lt;&gt;
+struct link:#C-0f[C]&lt;int, char&gt;;
+----
+
+[#C-03]
+== link:#C-0f[C]&lt;int&gt;
+
+=== Synopsis
+
+Declared in `&lt;sort&hyphen;namespace&hyphen;members&hyphen;by&hyphen;location&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+template&lt;&gt;
+struct link:#C-0f[C]&lt;int&gt;;
+----
+
+[#B-0b]
+== B
+
+=== Synopsis
+
+Declared in `&lt;sort&hyphen;namespace&hyphen;members&hyphen;by&hyphen;location&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+template&lt;
+    class T,
+    class U&gt;
+struct B;
+----
+
+[#B-04]
+== link:#B-0b[B]&lt;int, char&gt;
+
+=== Synopsis
+
+Declared in `&lt;sort&hyphen;namespace&hyphen;members&hyphen;by&hyphen;location&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+template&lt;&gt;
+struct link:#B-0b[B]&lt;int, char&gt;;
+----
+
+[#B-05]
+== link:#B-0b[B]&lt;int, U&gt;
+
+=== Synopsis
+
+Declared in `&lt;sort&hyphen;namespace&hyphen;members&hyphen;by&hyphen;location&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+template&lt;class U&gt;
+struct link:#B-0b[B]&lt;int, U&gt;;
+----
+
+[#A]
+== A
+
+=== Synopsis
+
+Declared in `&lt;sort&hyphen;namespace&hyphen;members&hyphen;by&hyphen;location&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+struct A;
+----
+
+[#Z]
+== Z
+
+=== Synopsis
+
+Declared in `&lt;sort&hyphen;namespace&hyphen;members&hyphen;by&hyphen;location&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+struct Z;
+----
+
+=== Member Functions
+
+[cols=2]
+|===
+| Name
+| Description
+| link:#Z-2constructor-00[`Z`]         [.small]#[constructor]#
+| Constructors
+| link:#Z-2destructor[`&#126;Z`] [.small]#[destructor]#
+| Destructor
+| link:#Z-foo[`foo`] 
+| 
+| link:#Z-2conversion[`operator bool`] 
+| Conversion to `bool`
+| link:#Z-operator_not[`operator!`] 
+| Negation operator
+| link:#Z-operator_eq[`operator&equals;&equals;`] 
+| Equality operator
+| link:#Z-operator_not_eq[`operator!&equals;`] 
+| Inequality operator
+| link:#Z-operator_3way[`operator&lt;&equals;&gt;`] 
+| Three&hyphen;way comparison operator
+|===
+
+[#Z-2constructor-00]
+== link:#Z[Z]::Z
+
+Constructors
+
+=== Synopses
+
+Declared in `&lt;sort&hyphen;namespace&hyphen;members&hyphen;by&hyphen;location&period;cpp&gt;`
+
+Default constructor
+
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+link:#Z-2constructor-05[Z]();
+----
+
+[.small]#link:#Z-2constructor-05[_» more&period;&period;&period;_]#
+
+Construct from `int`
+
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+link:#Z-2constructor-06[Z](int value);
+----
+
+[.small]#link:#Z-2constructor-06[_» more&period;&period;&period;_]#
+
+[#Z-2constructor-05]
+== link:#Z[Z]::Z
+
+Default constructor
+
+=== Synopsis
+
+Declared in `&lt;sort&hyphen;namespace&hyphen;members&hyphen;by&hyphen;location&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+Z();
+----
+
+[#Z-2constructor-06]
+== link:#Z[Z]::Z
+
+Construct from `int`
+
+=== Synopsis
+
+Declared in `&lt;sort&hyphen;namespace&hyphen;members&hyphen;by&hyphen;location&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+Z(int value);
+----
+
+=== Parameters
+
+[cols=2]
+|===
+| Name
+| Description
+| *value*
+| The value to construct from
+|===
+
+[#Z-2destructor]
+== link:#Z[Z]::&#126;Z
+
+Destructor
+
+=== Synopsis
+
+Declared in `&lt;sort&hyphen;namespace&hyphen;members&hyphen;by&hyphen;location&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+&#126;Z();
+----
+
+[#Z-foo]
+== link:#Z[Z]::foo
+
+=== Synopsis
+
+Declared in `&lt;sort&hyphen;namespace&hyphen;members&hyphen;by&hyphen;location&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+void
+foo() const;
+----
+
+[#Z-2conversion]
+== link:#Z[Z]::operator bool
+
+Conversion to `bool`
+
+=== Synopsis
+
+Declared in `&lt;sort&hyphen;namespace&hyphen;members&hyphen;by&hyphen;location&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+operator bool() const;
+----
+
+=== Return Value
+
+The object converted to `bool`
+
+[#Z-operator_not]
+== link:#Z[Z]::operator!
+
+Negation operator
+
+=== Synopsis
+
+Declared in `&lt;sort&hyphen;namespace&hyphen;members&hyphen;by&hyphen;location&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+bool
+operator!() const;
+----
+
+=== Return Value
+
+`true` if the object is falsy, `false` otherwise
+
+[#Z-operator_eq]
+== link:#Z[Z]::operator&equals;&equals;
+
+Equality operator
+
+=== Synopsis
+
+Declared in `&lt;sort&hyphen;namespace&hyphen;members&hyphen;by&hyphen;location&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+bool
+operator&equals;&equals;(link:#Z[Z] const& rhs) const;
+----
+
+=== Return Value
+
+`true` if the objects are equal, `false` otherwise
+
+=== Parameters
+
+[cols=2]
+|===
+| Name
+| Description
+| *rhs*
+| The right operand
+|===
+
+[#Z-operator_not_eq]
+== link:#Z[Z]::operator!&equals;
+
+Inequality operator
+
+=== Synopsis
+
+Declared in `&lt;sort&hyphen;namespace&hyphen;members&hyphen;by&hyphen;location&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+bool
+operator!&equals;(link:#Z[Z] const& rhs) const;
+----
+
+=== Return Value
+
+`true` if the objects are not equal, `false` otherwise
+
+=== Parameters
+
+[cols=2]
+|===
+| Name
+| Description
+| *rhs*
+| The right operand
+|===
+
+[#Z-operator_3way]
+== link:#Z[Z]::operator&lt;&equals;&gt;
+
+Three&hyphen;way comparison operator
+
+=== Synopsis
+
+Declared in `&lt;sort&hyphen;namespace&hyphen;members&hyphen;by&hyphen;location&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+auto
+operator&lt;&equals;&gt;(link:#Z[Z] const& rhs) const;
+----
+
+=== Return Value
+
+The relative order of the objects
+
+=== Parameters
+
+[cols=2]
+|===
+| Name
+| Description
+| *rhs*
+| The right operand
+|===
+
+[#h]
+== h
+
+=== Synopsis
+
+Declared in `&lt;sort&hyphen;namespace&hyphen;members&hyphen;by&hyphen;location&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+void
+h();
+----
+
+[#g-0f]
+== g
+
+=== Synopses
+
+Declared in `&lt;sort&hyphen;namespace&hyphen;members&hyphen;by&hyphen;location&period;cpp&gt;`
+
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+template&lt;class T&gt;
+char
+link:#g-03c[g](
+    T,
+    T,
+    T);
+----
+
+[.small]#link:#g-03c[_» more&period;&period;&period;_]#
+
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+template&lt;&gt;
+char
+link:#g-0e4[g&lt;int&gt;](
+    int,
+    int,
+    int);
+----
+
+[.small]#link:#g-0e4[_» more&period;&period;&period;_]#
+
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+char
+link:#g-0a[g](
+    char,
+    char,
+    char);
+----
+
+[.small]#link:#g-0a[_» more&period;&period;&period;_]#
+
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+char
+link:#g-03a[g](
+    double,
+    char);
+----
+
+[.small]#link:#g-03a[_» more&period;&period;&period;_]#
+
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+char
+link:#g-06[g](double);
+----
+
+[.small]#link:#g-06[_» more&period;&period;&period;_]#
+
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+char
+link:#g-04[g](int);
+----
+
+[.small]#link:#g-04[_» more&period;&period;&period;_]#
+
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+void
+link:#g-0e3[g]();
+----
+
+[.small]#link:#g-0e3[_» more&period;&period;&period;_]#
+
+[#g-03c]
+== g
+
+=== Synopsis
+
+Declared in `&lt;sort&hyphen;namespace&hyphen;members&hyphen;by&hyphen;location&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+template&lt;class T&gt;
+char
+g(
+    T,
+    T,
+    T);
+----
+
+[#g-0e4]
+== link:#g-03c[g]&lt;int&gt;
+
+=== Synopsis
+
+Declared in `&lt;sort&hyphen;namespace&hyphen;members&hyphen;by&hyphen;location&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+template&lt;&gt;
+char
+link:#g-03c[g]&lt;int&gt;(
+    int,
+    int,
+    int);
+----
+
+[#g-0a]
+== g
+
+=== Synopsis
+
+Declared in `&lt;sort&hyphen;namespace&hyphen;members&hyphen;by&hyphen;location&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+char
+g(
+    char,
+    char,
+    char);
+----
+
+[#g-03a]
+== g
+
+=== Synopsis
+
+Declared in `&lt;sort&hyphen;namespace&hyphen;members&hyphen;by&hyphen;location&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+char
+g(
+    double,
+    char);
+----
+
+[#g-06]
+== g
+
+=== Synopsis
+
+Declared in `&lt;sort&hyphen;namespace&hyphen;members&hyphen;by&hyphen;location&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+char
+g(double);
+----
+
+[#g-04]
+== g
+
+=== Synopsis
+
+Declared in `&lt;sort&hyphen;namespace&hyphen;members&hyphen;by&hyphen;location&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+char
+g(int);
+----
+
+[#g-0e3]
+== g
+
+=== Synopsis
+
+Declared in `&lt;sort&hyphen;namespace&hyphen;members&hyphen;by&hyphen;location&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+void
+g();
+----
+
+[#f]
+== f
+
+=== Synopsis
+
+Declared in `&lt;sort&hyphen;namespace&hyphen;members&hyphen;by&hyphen;location&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+void
+f();
+----
+
+[#operator_not]
+== operator!
+
+Negation operator
+
+=== Synopsis
+
+Declared in `&lt;sort&hyphen;namespace&hyphen;members&hyphen;by&hyphen;location&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+bool
+operator!(link:#A[A] const& v);
+----
+
+=== Return Value
+
+`true` if the object is falsy, `false` otherwise
+
+=== Parameters
+
+[cols=2]
+|===
+| Name
+| Description
+| *v*
+| The operand
+|===
+
+[#operator_eq]
+== operator&equals;&equals;
+
+Equality operator
+
+=== Synopsis
+
+Declared in `&lt;sort&hyphen;namespace&hyphen;members&hyphen;by&hyphen;location&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+bool
+operator&equals;&equals;(
+    link:#A[A] const& lhs,
+    link:#A[A] const& rhs);
+----
+
+=== Return Value
+
+`true` if the objects are equal, `false` otherwise
+
+=== Parameters
+
+[cols=2]
+|===
+| Name
+| Description
+| *lhs*
+| The left operand
+| *rhs*
+| The right operand
+|===
+
+[#operator_not_eq]
+== operator!&equals;
+
+Inequality operator
+
+=== Synopsis
+
+Declared in `&lt;sort&hyphen;namespace&hyphen;members&hyphen;by&hyphen;location&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+bool
+operator!&equals;(
+    link:#A[A] const& lhs,
+    link:#A[A] const& rhs);
+----
+
+=== Return Value
+
+`true` if the objects are not equal, `false` otherwise
+
+=== Parameters
+
+[cols=2]
+|===
+| Name
+| Description
+| *lhs*
+| The left operand
+| *rhs*
+| The right operand
+|===
+
+
+[.small]#Created with https://www.mrdocs.com[MrDocs]#

--- a/test-files/golden-tests/config/sort-namespace-members-by/sort-namespace-members-by-location.cpp
+++ b/test-files/golden-tests/config/sort-namespace-members-by/sort-namespace-members-by-location.cpp
@@ -1,0 +1,60 @@
+struct D {};
+
+template <class T, class U = void>
+struct C {};
+
+template <>
+struct C<int, char> {};
+
+template <>
+struct C<int> {};
+
+template <class T, class U>
+struct B {};
+
+template <>
+struct B<int, char> {};
+
+template <class U>
+struct B<int, U> {};
+
+struct A {};
+
+struct Z {
+    auto operator<=>(Z const&) const;
+    bool operator!=(Z const&) const;
+    bool operator==(Z const&) const;
+    bool operator!() const;
+    operator bool() const;
+    void foo() const;
+    ~Z();
+    Z(int);
+    Z();
+};
+
+bool operator!=(A const& lhs, A const& rhs);
+bool operator==(A const& lhs, A const& rhs);
+bool operator!(A const& v);
+
+void h();
+
+template <class T>
+char g(T, T, T);
+
+template <>
+char g<int>(int, int, int);
+
+char g(char, char, char);
+
+char g(double, char);
+
+char g(double);
+
+char g(int);
+
+char g(int);
+
+void g();
+
+void f();
+

--- a/test-files/golden-tests/config/sort-namespace-members-by/sort-namespace-members-by-location.html
+++ b/test-files/golden-tests/config/sort-namespace-members-by/sort-namespace-members-by-location.html
@@ -40,12 +40,12 @@
 </thead>
 <tbody>
 <tr>
-<td><a href="#operator_not_eq"><code>operator!&#x3D;</code></a> </td><td><span>Inequality operator</span></td></tr><tr>
-<td><a href="#operator_eq"><code>operator&#x3D;&#x3D;</code></a> </td><td><span>Equality operator</span></td></tr><tr>
-<td><a href="#operator_not"><code>operator!</code></a> </td><td><span>Negation operator</span></td></tr><tr>
 <td><a href="#h"><code>h</code></a> </td><td><span></span></td></tr><tr>
 <td><a href="#g-0f"><code>g</code></a> </td><td><span></span></td></tr><tr>
-<td><a href="#f"><code>f</code></a> </td><td><span></span></td></tr>
+<td><a href="#f"><code>f</code></a> </td><td><span></span></td></tr><tr>
+<td><a href="#operator_not"><code>operator!</code></a> </td><td><span>Negation operator</span></td></tr><tr>
+<td><a href="#operator_eq"><code>operator&#x3D;&#x3D;</code></a> </td><td><span>Equality operator</span></td></tr><tr>
+<td><a href="#operator_not_eq"><code>operator!&#x3D;</code></a> </td><td><span>Inequality operator</span></td></tr>
 </tbody>
 </table>
 
@@ -57,7 +57,7 @@
 <div>
 <h3>Synopsis</h3>
 <div>
-Declared in <code>&lt;unordered.cpp&gt;</code></div>
+Declared in <code>&lt;sort-namespace-members-by-location.cpp&gt;</code></div>
 <pre>
 <code class="source-code cpp">struct D;
 
@@ -74,7 +74,7 @@ Declared in <code>&lt;unordered.cpp&gt;</code></div>
 <div>
 <h3>Synopsis</h3>
 <div>
-Declared in <code>&lt;unordered.cpp&gt;</code></div>
+Declared in <code>&lt;sort-namespace-members-by-location.cpp&gt;</code></div>
 <pre>
 <code class="source-code cpp">template&lt;
     class T,
@@ -94,7 +94,7 @@ struct C;
 <div>
 <h3>Synopsis</h3>
 <div>
-Declared in <code>&lt;unordered.cpp&gt;</code></div>
+Declared in <code>&lt;sort-namespace-members-by-location.cpp&gt;</code></div>
 <pre>
 <code class="source-code cpp">template&lt;&gt;
 struct <a href="#C-0f">C</a>&lt;int, char&gt;;
@@ -112,7 +112,7 @@ struct <a href="#C-0f">C</a>&lt;int, char&gt;;
 <div>
 <h3>Synopsis</h3>
 <div>
-Declared in <code>&lt;unordered.cpp&gt;</code></div>
+Declared in <code>&lt;sort-namespace-members-by-location.cpp&gt;</code></div>
 <pre>
 <code class="source-code cpp">template&lt;&gt;
 struct <a href="#C-0f">C</a>&lt;int&gt;;
@@ -130,7 +130,7 @@ struct <a href="#C-0f">C</a>&lt;int&gt;;
 <div>
 <h3>Synopsis</h3>
 <div>
-Declared in <code>&lt;unordered.cpp&gt;</code></div>
+Declared in <code>&lt;sort-namespace-members-by-location.cpp&gt;</code></div>
 <pre>
 <code class="source-code cpp">template&lt;
     class T,
@@ -150,7 +150,7 @@ struct B;
 <div>
 <h3>Synopsis</h3>
 <div>
-Declared in <code>&lt;unordered.cpp&gt;</code></div>
+Declared in <code>&lt;sort-namespace-members-by-location.cpp&gt;</code></div>
 <pre>
 <code class="source-code cpp">template&lt;&gt;
 struct <a href="#B-0b">B</a>&lt;int, char&gt;;
@@ -168,7 +168,7 @@ struct <a href="#B-0b">B</a>&lt;int, char&gt;;
 <div>
 <h3>Synopsis</h3>
 <div>
-Declared in <code>&lt;unordered.cpp&gt;</code></div>
+Declared in <code>&lt;sort-namespace-members-by-location.cpp&gt;</code></div>
 <pre>
 <code class="source-code cpp">template&lt;class U&gt;
 struct <a href="#B-0b">B</a>&lt;int, U&gt;;
@@ -186,7 +186,7 @@ struct <a href="#B-0b">B</a>&lt;int, U&gt;;
 <div>
 <h3>Synopsis</h3>
 <div>
-Declared in <code>&lt;unordered.cpp&gt;</code></div>
+Declared in <code>&lt;sort-namespace-members-by-location.cpp&gt;</code></div>
 <pre>
 <code class="source-code cpp">struct A;
 
@@ -203,7 +203,7 @@ Declared in <code>&lt;unordered.cpp&gt;</code></div>
 <div>
 <h3>Synopsis</h3>
 <div>
-Declared in <code>&lt;unordered.cpp&gt;</code></div>
+Declared in <code>&lt;sort-namespace-members-by-location.cpp&gt;</code></div>
 <pre>
 <code class="source-code cpp">struct Z;
 
@@ -220,14 +220,14 @@ Declared in <code>&lt;unordered.cpp&gt;</code></div>
 </thead>
 <tbody>
 <tr>
-<td><a href="#Z-operator_3way"><code>operator&lt;&#x3D;&gt;</code></a> </td><td><span>Three-way comparison operator</span></td></tr><tr>
-<td><a href="#Z-operator_not_eq"><code>operator!&#x3D;</code></a> </td><td><span>Inequality operator</span></td></tr><tr>
-<td><a href="#Z-operator_eq"><code>operator&#x3D;&#x3D;</code></a> </td><td><span>Equality operator</span></td></tr><tr>
-<td><a href="#Z-operator_not"><code>operator!</code></a> </td><td><span>Negation operator</span></td></tr><tr>
-<td><a href="#Z-2conversion"><code>operator bool</code></a> </td><td><span>Conversion to <code>bool</code></span></td></tr><tr>
-<td><a href="#Z-foo"><code>foo</code></a> </td><td><span></span></td></tr><tr>
+<td><a href="#Z-2constructor-00"><code>Z</code></a>         <span class="small">[constructor]</span></td><td><span>Constructors</span></td></tr><tr>
 <td><a href="#Z-2destructor"><code>~Z</code></a> <span class="small">[destructor]</span></td><td><span>Destructor</span></td></tr><tr>
-<td><a href="#Z-2constructor-00"><code>Z</code></a>         <span class="small">[constructor]</span></td><td><span>Constructors</span></td></tr>
+<td><a href="#Z-foo"><code>foo</code></a> </td><td><span></span></td></tr><tr>
+<td><a href="#Z-2conversion"><code>operator bool</code></a> </td><td><span>Conversion to <code>bool</code></span></td></tr><tr>
+<td><a href="#Z-operator_not"><code>operator!</code></a> </td><td><span>Negation operator</span></td></tr><tr>
+<td><a href="#Z-operator_eq"><code>operator&#x3D;&#x3D;</code></a> </td><td><span>Equality operator</span></td></tr><tr>
+<td><a href="#Z-operator_not_eq"><code>operator!&#x3D;</code></a> </td><td><span>Inequality operator</span></td></tr><tr>
+<td><a href="#Z-operator_3way"><code>operator&lt;&#x3D;&gt;</code></a> </td><td><span>Three-way comparison operator</span></td></tr>
 </tbody>
 </table>
 
@@ -236,26 +236,69 @@ Declared in <code>&lt;unordered.cpp&gt;</code></div>
 </div>
 <div>
 <div>
-<h2 id="Z-operator_3way"><a href="#Z-operator_3way">Z::operator&lt;&#x3D;&gt;</a></h2>
+<h2 id="Z-2constructor-00"><a href="#Z-2constructor-00">Z::Z</a></h2>
 <div>
-<span>Three-way comparison operator</span>
+<span>Constructors</span>
+
+</div>
+</div>
+<div>
+<h3>Synopses</h3>
+<div>
+Declared in <code>&lt;sort-namespace-members-by-location.cpp&gt;</code></div>
+<span>Default constructor</span>
+<pre>
+<code class="source-code cpp"><a href="#Z-2constructor-05">Z</a>();
+
+</code>
+</pre><span class="small"><a href="#Z-2constructor-05"><em>» more...</em></a></span>
+
+<span>Construct from <code>int</code></span>
+<pre>
+<code class="source-code cpp"><a href="#Z-2constructor-06">Z</a>(int value);
+
+</code>
+</pre><span class="small"><a href="#Z-2constructor-06"><em>» more...</em></a></span>
+
+
+</div>
+</div>
+<div>
+<div>
+<h2 id="Z-2constructor-05"><a href="#Z-2constructor-05">Z::Z</a></h2>
+<div>
+<span>Default constructor</span>
 
 </div>
 </div>
 <div>
 <h3>Synopsis</h3>
 <div>
-Declared in <code>&lt;unordered.cpp&gt;</code></div>
+Declared in <code>&lt;sort-namespace-members-by-location.cpp&gt;</code></div>
 <pre>
-<code class="source-code cpp">auto
-operator&lt;&#x3D;&gt;(<a href="#Z">Z</a> const& rhs) const;
+<code class="source-code cpp">Z();
 
 </code>
 </pre>
 </div>
+</div>
 <div>
-<h3>Return Value</h3>
-<span>The relative order of the objects</span>
+<div>
+<h2 id="Z-2constructor-06"><a href="#Z-2constructor-06">Z::Z</a></h2>
+<div>
+<span>Construct from <code>int</code></span>
+
+</div>
+</div>
+<div>
+<h3>Synopsis</h3>
+<div>
+Declared in <code>&lt;sort-namespace-members-by-location.cpp&gt;</code></div>
+<pre>
+<code class="source-code cpp">Z(int value);
+
+</code>
+</pre>
 </div>
 <div>
 <h3>Parameters</h3>
@@ -268,8 +311,8 @@ operator&lt;&#x3D;&gt;(<a href="#Z">Z</a> const& rhs) const;
 </thead>
 <tbody>
 <tr>
-<td><strong>rhs</strong></td>
-<td><span>The right operand</span></td>
+<td><strong>value</strong></td>
+<td><span>The value to construct from</span></td>
 </tr>
 </tbody>
 </table>
@@ -277,43 +320,84 @@ operator&lt;&#x3D;&gt;(<a href="#Z">Z</a> const& rhs) const;
 </div>
 <div>
 <div>
-<h2 id="Z-operator_not_eq"><a href="#Z-operator_not_eq">Z::operator!&#x3D;</a></h2>
+<h2 id="Z-2destructor"><a href="#Z-2destructor">Z::~Z</a></h2>
 <div>
-<span>Inequality operator</span>
+<span>Destructor</span>
 
 </div>
 </div>
 <div>
 <h3>Synopsis</h3>
 <div>
-Declared in <code>&lt;unordered.cpp&gt;</code></div>
+Declared in <code>&lt;sort-namespace-members-by-location.cpp&gt;</code></div>
+<pre>
+<code class="source-code cpp">~Z();
+
+</code>
+</pre>
+</div>
+</div>
+<div>
+<div>
+<h2 id="Z-foo"><a href="#Z-foo">Z::foo</a></h2>
+</div>
+<div>
+<h3>Synopsis</h3>
+<div>
+Declared in <code>&lt;sort-namespace-members-by-location.cpp&gt;</code></div>
+<pre>
+<code class="source-code cpp">void
+foo() const;
+
+</code>
+</pre>
+</div>
+</div>
+<div>
+<div>
+<h2 id="Z-2conversion"><a href="#Z-2conversion">Z::operator bool</a></h2>
+<div>
+<span>Conversion to <code>bool</code></span>
+
+</div>
+</div>
+<div>
+<h3>Synopsis</h3>
+<div>
+Declared in <code>&lt;sort-namespace-members-by-location.cpp&gt;</code></div>
+<pre>
+<code class="source-code cpp">operator bool() const;
+
+</code>
+</pre>
+</div>
+<div>
+<h3>Return Value</h3>
+<span>The object converted to <code>bool</code></span>
+</div>
+</div>
+<div>
+<div>
+<h2 id="Z-operator_not"><a href="#Z-operator_not">Z::operator!</a></h2>
+<div>
+<span>Negation operator</span>
+
+</div>
+</div>
+<div>
+<h3>Synopsis</h3>
+<div>
+Declared in <code>&lt;sort-namespace-members-by-location.cpp&gt;</code></div>
 <pre>
 <code class="source-code cpp">bool
-operator!&#x3D;(<a href="#Z">Z</a> const& rhs) const;
+operator!() const;
 
 </code>
 </pre>
 </div>
 <div>
 <h3>Return Value</h3>
-<span><code>true</code> if the objects are not equal, <code>false</code> otherwise</span>
-</div>
-<div>
-<h3>Parameters</h3>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td><strong>rhs</strong></td>
-<td><span>The right operand</span></td>
-</tr>
-</tbody>
-</table>
+<span><code>true</code> if the object is falsy, <code>false</code> otherwise</span>
 </div>
 </div>
 <div>
@@ -327,7 +411,7 @@ operator!&#x3D;(<a href="#Z">Z</a> const& rhs) const;
 <div>
 <h3>Synopsis</h3>
 <div>
-Declared in <code>&lt;unordered.cpp&gt;</code></div>
+Declared in <code>&lt;sort-namespace-members-by-location.cpp&gt;</code></div>
 <pre>
 <code class="source-code cpp">bool
 operator&#x3D;&#x3D;(<a href="#Z">Z</a> const& rhs) const;
@@ -359,173 +443,7 @@ operator&#x3D;&#x3D;(<a href="#Z">Z</a> const& rhs) const;
 </div>
 <div>
 <div>
-<h2 id="Z-operator_not"><a href="#Z-operator_not">Z::operator!</a></h2>
-<div>
-<span>Negation operator</span>
-
-</div>
-</div>
-<div>
-<h3>Synopsis</h3>
-<div>
-Declared in <code>&lt;unordered.cpp&gt;</code></div>
-<pre>
-<code class="source-code cpp">bool
-operator!() const;
-
-</code>
-</pre>
-</div>
-<div>
-<h3>Return Value</h3>
-<span><code>true</code> if the object is falsy, <code>false</code> otherwise</span>
-</div>
-</div>
-<div>
-<div>
-<h2 id="Z-2conversion"><a href="#Z-2conversion">Z::operator bool</a></h2>
-<div>
-<span>Conversion to <code>bool</code></span>
-
-</div>
-</div>
-<div>
-<h3>Synopsis</h3>
-<div>
-Declared in <code>&lt;unordered.cpp&gt;</code></div>
-<pre>
-<code class="source-code cpp">operator bool() const;
-
-</code>
-</pre>
-</div>
-<div>
-<h3>Return Value</h3>
-<span>The object converted to <code>bool</code></span>
-</div>
-</div>
-<div>
-<div>
-<h2 id="Z-foo"><a href="#Z-foo">Z::foo</a></h2>
-</div>
-<div>
-<h3>Synopsis</h3>
-<div>
-Declared in <code>&lt;unordered.cpp&gt;</code></div>
-<pre>
-<code class="source-code cpp">void
-foo() const;
-
-</code>
-</pre>
-</div>
-</div>
-<div>
-<div>
-<h2 id="Z-2destructor"><a href="#Z-2destructor">Z::~Z</a></h2>
-<div>
-<span>Destructor</span>
-
-</div>
-</div>
-<div>
-<h3>Synopsis</h3>
-<div>
-Declared in <code>&lt;unordered.cpp&gt;</code></div>
-<pre>
-<code class="source-code cpp">~Z();
-
-</code>
-</pre>
-</div>
-</div>
-<div>
-<div>
-<h2 id="Z-2constructor-00"><a href="#Z-2constructor-00">Z::Z</a></h2>
-<div>
-<span>Constructors</span>
-
-</div>
-</div>
-<div>
-<h3>Synopses</h3>
-<div>
-Declared in <code>&lt;unordered.cpp&gt;</code></div>
-<span>Default constructor</span>
-<pre>
-<code class="source-code cpp"><a href="#Z-2constructor-05">Z</a>();
-
-</code>
-</pre><span class="small"><a href="#Z-2constructor-05"><em>» more...</em></a></span>
-
-<span>Construct from <code>int</code></span>
-<pre>
-<code class="source-code cpp"><a href="#Z-2constructor-06">Z</a>(int value);
-
-</code>
-</pre><span class="small"><a href="#Z-2constructor-06"><em>» more...</em></a></span>
-
-
-</div>
-</div>
-<div>
-<div>
-<h2 id="Z-2constructor-05"><a href="#Z-2constructor-05">Z::Z</a></h2>
-<div>
-<span>Default constructor</span>
-
-</div>
-</div>
-<div>
-<h3>Synopsis</h3>
-<div>
-Declared in <code>&lt;unordered.cpp&gt;</code></div>
-<pre>
-<code class="source-code cpp">Z();
-
-</code>
-</pre>
-</div>
-</div>
-<div>
-<div>
-<h2 id="Z-2constructor-06"><a href="#Z-2constructor-06">Z::Z</a></h2>
-<div>
-<span>Construct from <code>int</code></span>
-
-</div>
-</div>
-<div>
-<h3>Synopsis</h3>
-<div>
-Declared in <code>&lt;unordered.cpp&gt;</code></div>
-<pre>
-<code class="source-code cpp">Z(int value);
-
-</code>
-</pre>
-</div>
-<div>
-<h3>Parameters</h3>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td><strong>value</strong></td>
-<td><span>The value to construct from</span></td>
-</tr>
-</tbody>
-</table>
-</div>
-</div>
-<div>
-<div>
-<h2 id="operator_not_eq"><a href="#operator_not_eq">operator!&#x3D;</a></h2>
+<h2 id="Z-operator_not_eq"><a href="#Z-operator_not_eq">Z::operator!&#x3D;</a></h2>
 <div>
 <span>Inequality operator</span>
 
@@ -534,12 +452,10 @@ Declared in <code>&lt;unordered.cpp&gt;</code></div>
 <div>
 <h3>Synopsis</h3>
 <div>
-Declared in <code>&lt;unordered.cpp&gt;</code></div>
+Declared in <code>&lt;sort-namespace-members-by-location.cpp&gt;</code></div>
 <pre>
 <code class="source-code cpp">bool
-operator!&#x3D;(
-    <a href="#A">A</a> const& lhs,
-    <a href="#A">A</a> const& rhs);
+operator!&#x3D;(<a href="#Z">Z</a> const& rhs) const;
 
 </code>
 </pre>
@@ -559,10 +475,6 @@ operator!&#x3D;(
 </thead>
 <tbody>
 <tr>
-<td><strong>lhs</strong></td>
-<td><span>The left operand</span></td>
-</tr>
-<tr>
 <td><strong>rhs</strong></td>
 <td><span>The right operand</span></td>
 </tr>
@@ -572,28 +484,26 @@ operator!&#x3D;(
 </div>
 <div>
 <div>
-<h2 id="operator_eq"><a href="#operator_eq">operator&#x3D;&#x3D;</a></h2>
+<h2 id="Z-operator_3way"><a href="#Z-operator_3way">Z::operator&lt;&#x3D;&gt;</a></h2>
 <div>
-<span>Equality operator</span>
+<span>Three-way comparison operator</span>
 
 </div>
 </div>
 <div>
 <h3>Synopsis</h3>
 <div>
-Declared in <code>&lt;unordered.cpp&gt;</code></div>
+Declared in <code>&lt;sort-namespace-members-by-location.cpp&gt;</code></div>
 <pre>
-<code class="source-code cpp">bool
-operator&#x3D;&#x3D;(
-    <a href="#A">A</a> const& lhs,
-    <a href="#A">A</a> const& rhs);
+<code class="source-code cpp">auto
+operator&lt;&#x3D;&gt;(<a href="#Z">Z</a> const& rhs) const;
 
 </code>
 </pre>
 </div>
 <div>
 <h3>Return Value</h3>
-<span><code>true</code> if the objects are equal, <code>false</code> otherwise</span>
+<span>The relative order of the objects</span>
 </div>
 <div>
 <h3>Parameters</h3>
@@ -606,53 +516,8 @@ operator&#x3D;&#x3D;(
 </thead>
 <tbody>
 <tr>
-<td><strong>lhs</strong></td>
-<td><span>The left operand</span></td>
-</tr>
-<tr>
 <td><strong>rhs</strong></td>
 <td><span>The right operand</span></td>
-</tr>
-</tbody>
-</table>
-</div>
-</div>
-<div>
-<div>
-<h2 id="operator_not"><a href="#operator_not">operator!</a></h2>
-<div>
-<span>Negation operator</span>
-
-</div>
-</div>
-<div>
-<h3>Synopsis</h3>
-<div>
-Declared in <code>&lt;unordered.cpp&gt;</code></div>
-<pre>
-<code class="source-code cpp">bool
-operator!(<a href="#A">A</a> const& v);
-
-</code>
-</pre>
-</div>
-<div>
-<h3>Return Value</h3>
-<span><code>true</code> if the object is falsy, <code>false</code> otherwise</span>
-</div>
-<div>
-<h3>Parameters</h3>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td><strong>v</strong></td>
-<td><span>The operand</span></td>
 </tr>
 </tbody>
 </table>
@@ -665,7 +530,7 @@ operator!(<a href="#A">A</a> const& v);
 <div>
 <h3>Synopsis</h3>
 <div>
-Declared in <code>&lt;unordered.cpp&gt;</code></div>
+Declared in <code>&lt;sort-namespace-members-by-location.cpp&gt;</code></div>
 <pre>
 <code class="source-code cpp">void
 h();
@@ -681,7 +546,7 @@ h();
 <div>
 <h3>Synopses</h3>
 <div>
-Declared in <code>&lt;unordered.cpp&gt;</code></div>
+Declared in <code>&lt;sort-namespace-members-by-location.cpp&gt;</code></div>
 
 <pre>
 <code class="source-code cpp">template&lt;class T&gt;
@@ -761,7 +626,7 @@ char
 <div>
 <h3>Synopsis</h3>
 <div>
-Declared in <code>&lt;unordered.cpp&gt;</code></div>
+Declared in <code>&lt;sort-namespace-members-by-location.cpp&gt;</code></div>
 <pre>
 <code class="source-code cpp">template&lt;class T&gt;
 char
@@ -781,7 +646,7 @@ g(
 <div>
 <h3>Synopsis</h3>
 <div>
-Declared in <code>&lt;unordered.cpp&gt;</code></div>
+Declared in <code>&lt;sort-namespace-members-by-location.cpp&gt;</code></div>
 <pre>
 <code class="source-code cpp">template&lt;&gt;
 char
@@ -801,7 +666,7 @@ char
 <div>
 <h3>Synopsis</h3>
 <div>
-Declared in <code>&lt;unordered.cpp&gt;</code></div>
+Declared in <code>&lt;sort-namespace-members-by-location.cpp&gt;</code></div>
 <pre>
 <code class="source-code cpp">char
 g(
@@ -820,7 +685,7 @@ g(
 <div>
 <h3>Synopsis</h3>
 <div>
-Declared in <code>&lt;unordered.cpp&gt;</code></div>
+Declared in <code>&lt;sort-namespace-members-by-location.cpp&gt;</code></div>
 <pre>
 <code class="source-code cpp">char
 g(
@@ -838,7 +703,7 @@ g(
 <div>
 <h3>Synopsis</h3>
 <div>
-Declared in <code>&lt;unordered.cpp&gt;</code></div>
+Declared in <code>&lt;sort-namespace-members-by-location.cpp&gt;</code></div>
 <pre>
 <code class="source-code cpp">char
 g(double);
@@ -854,7 +719,7 @@ g(double);
 <div>
 <h3>Synopsis</h3>
 <div>
-Declared in <code>&lt;unordered.cpp&gt;</code></div>
+Declared in <code>&lt;sort-namespace-members-by-location.cpp&gt;</code></div>
 <pre>
 <code class="source-code cpp">char
 g(int);
@@ -870,7 +735,7 @@ g(int);
 <div>
 <h3>Synopsis</h3>
 <div>
-Declared in <code>&lt;unordered.cpp&gt;</code></div>
+Declared in <code>&lt;sort-namespace-members-by-location.cpp&gt;</code></div>
 <pre>
 <code class="source-code cpp">void
 g();
@@ -886,13 +751,148 @@ g();
 <div>
 <h3>Synopsis</h3>
 <div>
-Declared in <code>&lt;unordered.cpp&gt;</code></div>
+Declared in <code>&lt;sort-namespace-members-by-location.cpp&gt;</code></div>
 <pre>
 <code class="source-code cpp">void
 f();
 
 </code>
 </pre>
+</div>
+</div>
+<div>
+<div>
+<h2 id="operator_not"><a href="#operator_not">operator!</a></h2>
+<div>
+<span>Negation operator</span>
+
+</div>
+</div>
+<div>
+<h3>Synopsis</h3>
+<div>
+Declared in <code>&lt;sort-namespace-members-by-location.cpp&gt;</code></div>
+<pre>
+<code class="source-code cpp">bool
+operator!(<a href="#A">A</a> const& v);
+
+</code>
+</pre>
+</div>
+<div>
+<h3>Return Value</h3>
+<span><code>true</code> if the object is falsy, <code>false</code> otherwise</span>
+</div>
+<div>
+<h3>Parameters</h3>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>v</strong></td>
+<td><span>The operand</span></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div>
+<div>
+<h2 id="operator_eq"><a href="#operator_eq">operator&#x3D;&#x3D;</a></h2>
+<div>
+<span>Equality operator</span>
+
+</div>
+</div>
+<div>
+<h3>Synopsis</h3>
+<div>
+Declared in <code>&lt;sort-namespace-members-by-location.cpp&gt;</code></div>
+<pre>
+<code class="source-code cpp">bool
+operator&#x3D;&#x3D;(
+    <a href="#A">A</a> const& lhs,
+    <a href="#A">A</a> const& rhs);
+
+</code>
+</pre>
+</div>
+<div>
+<h3>Return Value</h3>
+<span><code>true</code> if the objects are equal, <code>false</code> otherwise</span>
+</div>
+<div>
+<h3>Parameters</h3>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>lhs</strong></td>
+<td><span>The left operand</span></td>
+</tr>
+<tr>
+<td><strong>rhs</strong></td>
+<td><span>The right operand</span></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div>
+<div>
+<h2 id="operator_not_eq"><a href="#operator_not_eq">operator!&#x3D;</a></h2>
+<div>
+<span>Inequality operator</span>
+
+</div>
+</div>
+<div>
+<h3>Synopsis</h3>
+<div>
+Declared in <code>&lt;sort-namespace-members-by-location.cpp&gt;</code></div>
+<pre>
+<code class="source-code cpp">bool
+operator!&#x3D;(
+    <a href="#A">A</a> const& lhs,
+    <a href="#A">A</a> const& rhs);
+
+</code>
+</pre>
+</div>
+<div>
+<h3>Return Value</h3>
+<span><code>true</code> if the objects are not equal, <code>false</code> otherwise</span>
+</div>
+<div>
+<h3>Parameters</h3>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>lhs</strong></td>
+<td><span>The left operand</span></td>
+</tr>
+<tr>
+<td><strong>rhs</strong></td>
+<td><span>The right operand</span></td>
+</tr>
+</tbody>
+</table>
 </div>
 </div>
 

--- a/test-files/golden-tests/config/sort-namespace-members-by/sort-namespace-members-by-location.xml
+++ b/test-files/golden-tests/config/sort-namespace-members-by/sort-namespace-members-by-location.xml
@@ -1,0 +1,392 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mrdocs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="https://github.com/cppalliance/mrdocs/raw/develop/mrdocs.rnc">
+<namespace id="//////////////////////////8=">
+  <struct name="D" id="CSFzdUEgi4+pu0K2D3isHXeaoFQ=">
+    <file short-path="sort-namespace-members-by-location.cpp" source-path="sort-namespace-members-by-location.cpp" line="1" class="def"/>
+  </struct>
+  <template>
+    <tparam name="T" class="type"/>
+    <tparam name="U" class="type" default="void"/>
+    <struct name="C" id="8nYw0KA23eAszqSOs0wOXAD1DYQ=">
+      <file short-path="sort-namespace-members-by-location.cpp" source-path="sort-namespace-members-by-location.cpp" line="3" class="def"/>
+    </struct>
+  </template>
+  <template class="explicit" id="8nYw0KA23eAszqSOs0wOXAD1DYQ=">
+    <targ class="type" type="int"/>
+    <targ class="type" type="char"/>
+    <struct name="C" id="1gG5jFtdo9Wauh4eNKJFnssDpFU=">
+      <file short-path="sort-namespace-members-by-location.cpp" source-path="sort-namespace-members-by-location.cpp" line="7" class="def"/>
+    </struct>
+  </template>
+  <template class="explicit" id="8nYw0KA23eAszqSOs0wOXAD1DYQ=">
+    <targ class="type" type="int"/>
+    <struct name="C" id="NLoLTepRVq6Wm8kqUGSEoM03TKg=">
+      <file short-path="sort-namespace-members-by-location.cpp" source-path="sort-namespace-members-by-location.cpp" line="10" class="def"/>
+    </struct>
+  </template>
+  <template>
+    <tparam name="T" class="type"/>
+    <tparam name="U" class="type"/>
+    <struct name="B" id="swBEqeWAJoaWVKty+1lCoYUK04A=">
+      <file short-path="sort-namespace-members-by-location.cpp" source-path="sort-namespace-members-by-location.cpp" line="12" class="def"/>
+    </struct>
+  </template>
+  <template class="explicit" id="swBEqeWAJoaWVKty+1lCoYUK04A=">
+    <targ class="type" type="int"/>
+    <targ class="type" type="char"/>
+    <struct name="B" id="S+FvHbXPEwSCkNHoe9TC9L5a4Yk=">
+      <file short-path="sort-namespace-members-by-location.cpp" source-path="sort-namespace-members-by-location.cpp" line="16" class="def"/>
+    </struct>
+  </template>
+  <template class="partial" id="swBEqeWAJoaWVKty+1lCoYUK04A=">
+    <tparam name="U" class="type"/>
+    <targ class="type" type="int"/>
+    <targ class="type" type="U"/>
+    <struct name="B" id="VwFE3CILPejPf11zTv20aat7w8Q=">
+      <file short-path="sort-namespace-members-by-location.cpp" source-path="sort-namespace-members-by-location.cpp" line="19" class="def"/>
+    </struct>
+  </template>
+  <struct name="A" id="YrPSaKAbmXgzCAX5WByx4eVoqBM=">
+    <file short-path="sort-namespace-members-by-location.cpp" source-path="sort-namespace-members-by-location.cpp" line="21" class="def"/>
+  </struct>
+  <struct name="Z" id="NQ8uQgTcafPcttyBMHHLHAXA4MA=">
+    <file short-path="sort-namespace-members-by-location.cpp" source-path="sort-namespace-members-by-location.cpp" line="23" class="def"/>
+    <function class="constructor" name="Z" id="WltomC+2IcmzMN0COGL0OWWmbZk=">
+      <file short-path="sort-namespace-members-by-location.cpp" source-path="sort-namespace-members-by-location.cpp" line="32"/>
+      <doc>
+        <brief>
+          <text>Default constructor</text>
+        </brief>
+      </doc>
+    </function>
+    <function class="constructor" name="Z" id="aQWtFVa4Xa+eceLXiLW74q44JRk=">
+      <file short-path="sort-namespace-members-by-location.cpp" source-path="sort-namespace-members-by-location.cpp" line="31"/>
+      <param name="value">
+        <type name="int"/>
+      </param>
+      <doc>
+        <brief>
+          <text>Construct from </text>
+          <mono>int</mono>
+        </brief>
+        <param name="value">
+          <text>The value to construct from</text>
+        </param>
+      </doc>
+    </function>
+    <function class="destructor" name="~Z" id="HMG56OCQ5OpB2E9hu4bG3/hoOho=">
+      <file short-path="sort-namespace-members-by-location.cpp" source-path="sort-namespace-members-by-location.cpp" line="30"/>
+      <doc>
+        <brief>
+          <text>Destructor</text>
+        </brief>
+      </doc>
+    </function>
+    <function name="foo" id="lBA1besl9J3wAZAcEn9C+K05hf4=">
+      <file short-path="sort-namespace-members-by-location.cpp" source-path="sort-namespace-members-by-location.cpp" line="29"/>
+      <attr id="is-const"/>
+    </function>
+    <function class="conversion" name="operator bool" id="zQ0DYAZMF+xhfbo8hUyqZRNKJ+U=">
+      <file short-path="sort-namespace-members-by-location.cpp" source-path="sort-namespace-members-by-location.cpp" line="28"/>
+      <attr id="is-const"/>
+      <return>
+        <type name="bool"/>
+      </return>
+      <doc>
+        <brief>
+          <text>Conversion to </text>
+          <mono>bool</mono>
+        </brief>
+        <returns>
+          <text>The object converted to </text>
+          <mono>bool</mono>
+        </returns>
+      </doc>
+    </function>
+    <function name="operator!" id="rjPdhFxUkaC43tWXi+kka78JQxI=">
+      <file short-path="sort-namespace-members-by-location.cpp" source-path="sort-namespace-members-by-location.cpp" line="27"/>
+      <attr id="operator" name="not" value="27"/>
+      <attr id="is-const"/>
+      <return>
+        <type name="bool"/>
+      </return>
+      <doc>
+        <brief>
+          <text>Negation operator</text>
+        </brief>
+        <returns>
+          <mono>true</mono>
+          <text> if the object is falsy, </text>
+          <mono>false</mono>
+          <text> otherwise</text>
+        </returns>
+      </doc>
+    </function>
+    <function name="operator==" id="atwUGLD+QHVhH3x1+8qzINNxzMY=">
+      <file short-path="sort-namespace-members-by-location.cpp" source-path="sort-namespace-members-by-location.cpp" line="26"/>
+      <attr id="operator" name="eq" value="28"/>
+      <attr id="is-const"/>
+      <return>
+        <type name="bool"/>
+      </return>
+      <param name="rhs">
+        <type class="lvalue-reference">
+          <pointee-type id="NQ8uQgTcafPcttyBMHHLHAXA4MA=" name="Z" cv-qualifiers="const"/>
+        </type>
+      </param>
+      <doc>
+        <brief>
+          <text>Equality operator</text>
+        </brief>
+        <returns>
+          <mono>true</mono>
+          <text> if the objects are equal, </text>
+          <mono>false</mono>
+          <text> otherwise</text>
+        </returns>
+        <param name="rhs">
+          <text>The right operand</text>
+        </param>
+      </doc>
+    </function>
+    <function name="operator!=" id="CB0pXrzU8BKZ2LF0BSpclxIfgrs=">
+      <file short-path="sort-namespace-members-by-location.cpp" source-path="sort-namespace-members-by-location.cpp" line="25"/>
+      <attr id="operator" name="not_eq" value="29"/>
+      <attr id="is-const"/>
+      <return>
+        <type name="bool"/>
+      </return>
+      <param name="rhs">
+        <type class="lvalue-reference">
+          <pointee-type id="NQ8uQgTcafPcttyBMHHLHAXA4MA=" name="Z" cv-qualifiers="const"/>
+        </type>
+      </param>
+      <doc>
+        <brief>
+          <text>Inequality operator</text>
+        </brief>
+        <returns>
+          <mono>true</mono>
+          <text> if the objects are not equal, </text>
+          <mono>false</mono>
+          <text> otherwise</text>
+        </returns>
+        <param name="rhs">
+          <text>The right operand</text>
+        </param>
+      </doc>
+    </function>
+    <function name="operator&lt;=&gt;" id="6/NYLeQdPqWrbu5kHnTpE3u6Yg4=">
+      <file short-path="sort-namespace-members-by-location.cpp" source-path="sort-namespace-members-by-location.cpp" line="24"/>
+      <attr id="operator" name="3way" value="34"/>
+      <attr id="is-const"/>
+      <return>
+        <type class="auto" keyword="auto">
+        </type>
+      </return>
+      <param name="rhs">
+        <type class="lvalue-reference">
+          <pointee-type id="NQ8uQgTcafPcttyBMHHLHAXA4MA=" name="Z" cv-qualifiers="const"/>
+        </type>
+      </param>
+      <doc>
+        <brief>
+          <text>Three-way comparison operator</text>
+        </brief>
+        <returns>
+          <text>The relative order of the objects</text>
+        </returns>
+        <param name="rhs">
+          <text>The right operand</text>
+        </param>
+      </doc>
+    </function>
+  </struct>
+  <function name="h" id="rvT6OxIrrSI0KxJ2nkfEgBz/Lz4=">
+    <file short-path="sort-namespace-members-by-location.cpp" source-path="sort-namespace-members-by-location.cpp" line="39"/>
+  </function>
+  <template>
+    <tparam name="T" class="type"/>
+    <function name="g" id="PEedgXj8uxMWKd/yZk6yqAz6boU=">
+      <file short-path="sort-namespace-members-by-location.cpp" source-path="sort-namespace-members-by-location.cpp" line="41"/>
+      <return>
+        <type name="char"/>
+      </return>
+      <param>
+        <type name="T"/>
+      </param>
+      <param>
+        <type name="T"/>
+      </param>
+      <param>
+        <type name="T"/>
+      </param>
+    </function>
+  </template>
+  <template class="explicit" id="PEedgXj8uxMWKd/yZk6yqAz6boU=">
+    <targ class="type" type="int"/>
+    <function name="g" id="5LjM4cXZ7IywLIZW1RtfpP7tNNk=">
+      <file short-path="sort-namespace-members-by-location.cpp" source-path="sort-namespace-members-by-location.cpp" line="44"/>
+      <return>
+        <type name="char"/>
+      </return>
+      <param>
+        <type name="int"/>
+      </param>
+      <param>
+        <type name="int"/>
+      </param>
+      <param>
+        <type name="int"/>
+      </param>
+    </function>
+  </template>
+  <function name="g" id="rs6F2A6K2Qvx34WDTz9fCKP4+HE=">
+    <file short-path="sort-namespace-members-by-location.cpp" source-path="sort-namespace-members-by-location.cpp" line="47"/>
+    <return>
+      <type name="char"/>
+    </return>
+    <param>
+      <type name="char"/>
+    </param>
+    <param>
+      <type name="char"/>
+    </param>
+    <param>
+      <type name="char"/>
+    </param>
+  </function>
+  <function name="g" id="OqSPxlq/89fBNIHVGkd2KTtgheY=">
+    <file short-path="sort-namespace-members-by-location.cpp" source-path="sort-namespace-members-by-location.cpp" line="49"/>
+    <return>
+      <type name="char"/>
+    </return>
+    <param>
+      <type name="double"/>
+    </param>
+    <param>
+      <type name="char"/>
+    </param>
+  </function>
+  <function name="g" id="ZYC+YG/hWLHomKHwEAfoO4TO2cw=">
+    <file short-path="sort-namespace-members-by-location.cpp" source-path="sort-namespace-members-by-location.cpp" line="51"/>
+    <return>
+      <type name="char"/>
+    </return>
+    <param>
+      <type name="double"/>
+    </param>
+  </function>
+  <function name="g" id="SvF6a1ZP8sdIXexPrrRDIA1OHus=">
+    <file short-path="sort-namespace-members-by-location.cpp" source-path="sort-namespace-members-by-location.cpp" line="53"/>
+    <file short-path="sort-namespace-members-by-location.cpp" source-path="sort-namespace-members-by-location.cpp" line="55"/>
+    <return>
+      <type name="char"/>
+    </return>
+    <param>
+      <type name="int"/>
+    </param>
+  </function>
+  <function name="g" id="43ASI/aC9fCLy8T+1gn7pUdis+g=">
+    <file short-path="sort-namespace-members-by-location.cpp" source-path="sort-namespace-members-by-location.cpp" line="57"/>
+  </function>
+  <function name="f" id="s6nsa+zVhpzzrN+yUVPP5rvdXqs=">
+    <file short-path="sort-namespace-members-by-location.cpp" source-path="sort-namespace-members-by-location.cpp" line="59"/>
+  </function>
+  <function name="operator!" id="yuKyBhGbND+Kyypyb9UsuC4Qe3E=">
+    <file short-path="sort-namespace-members-by-location.cpp" source-path="sort-namespace-members-by-location.cpp" line="37"/>
+    <attr id="operator" name="not" value="27"/>
+    <return>
+      <type name="bool"/>
+    </return>
+    <param name="v">
+      <type class="lvalue-reference">
+        <pointee-type id="YrPSaKAbmXgzCAX5WByx4eVoqBM=" name="A" cv-qualifiers="const"/>
+      </type>
+    </param>
+    <doc>
+      <brief>
+        <text>Negation operator</text>
+      </brief>
+      <returns>
+        <mono>true</mono>
+        <text> if the object is falsy, </text>
+        <mono>false</mono>
+        <text> otherwise</text>
+      </returns>
+      <param name="v">
+        <text>The operand</text>
+      </param>
+    </doc>
+  </function>
+  <function name="operator==" id="kibUx6k1SXB+HsXkRXroJl9f59w=">
+    <file short-path="sort-namespace-members-by-location.cpp" source-path="sort-namespace-members-by-location.cpp" line="36"/>
+    <attr id="operator" name="eq" value="28"/>
+    <return>
+      <type name="bool"/>
+    </return>
+    <param name="lhs">
+      <type class="lvalue-reference">
+        <pointee-type id="YrPSaKAbmXgzCAX5WByx4eVoqBM=" name="A" cv-qualifiers="const"/>
+      </type>
+    </param>
+    <param name="rhs">
+      <type class="lvalue-reference">
+        <pointee-type id="YrPSaKAbmXgzCAX5WByx4eVoqBM=" name="A" cv-qualifiers="const"/>
+      </type>
+    </param>
+    <doc>
+      <brief>
+        <text>Equality operator</text>
+      </brief>
+      <returns>
+        <mono>true</mono>
+        <text> if the objects are equal, </text>
+        <mono>false</mono>
+        <text> otherwise</text>
+      </returns>
+      <param name="lhs">
+        <text>The left operand</text>
+      </param>
+      <param name="rhs">
+        <text>The right operand</text>
+      </param>
+    </doc>
+  </function>
+  <function name="operator!=" id="4MuN1V3fHVfOMvtg2LT+QVm/XmE=">
+    <file short-path="sort-namespace-members-by-location.cpp" source-path="sort-namespace-members-by-location.cpp" line="35"/>
+    <attr id="operator" name="not_eq" value="29"/>
+    <return>
+      <type name="bool"/>
+    </return>
+    <param name="lhs">
+      <type class="lvalue-reference">
+        <pointee-type id="YrPSaKAbmXgzCAX5WByx4eVoqBM=" name="A" cv-qualifiers="const"/>
+      </type>
+    </param>
+    <param name="rhs">
+      <type class="lvalue-reference">
+        <pointee-type id="YrPSaKAbmXgzCAX5WByx4eVoqBM=" name="A" cv-qualifiers="const"/>
+      </type>
+    </param>
+    <doc>
+      <brief>
+        <text>Inequality operator</text>
+      </brief>
+      <returns>
+        <mono>true</mono>
+        <text> if the objects are not equal, </text>
+        <mono>false</mono>
+        <text> otherwise</text>
+      </returns>
+      <param name="lhs">
+        <text>The left operand</text>
+      </param>
+      <param name="rhs">
+        <text>The right operand</text>
+      </param>
+    </doc>
+  </function>
+</namespace>
+</mrdocs>

--- a/test-files/golden-tests/config/sort-namespace-members-by/sort-namespace-members-by-location.yml
+++ b/test-files/golden-tests/config/sort-namespace-members-by/sort-namespace-members-by-location.yml
@@ -1,0 +1,1 @@
+sort-namespace-members-by: location

--- a/test-files/golden-tests/config/sort-namespace-members-by/sort-namespace-members-by-name.adoc
+++ b/test-files/golden-tests/config/sort-namespace-members-by/sort-namespace-members-by-name.adoc
@@ -1,0 +1,712 @@
+= Reference
+:mrdocs:
+
+[#index]
+== Global namespace
+
+=== Types
+
+[cols=1]
+|===
+| Name
+| link:#A[`A`] 
+| link:#B-0b[`B`] 
+| link:#B-04[`B&lt;int, char&gt;`] 
+| link:#B-05[`B&lt;int, U&gt;`] 
+| link:#C-0f[`C`] 
+| link:#C-03[`C&lt;int&gt;`] 
+| link:#C-0d[`C&lt;int, char&gt;`] 
+| link:#D[`D`] 
+| link:#Z[`Z`] 
+|===
+
+=== Functions
+
+[cols=2]
+|===
+| Name
+| Description
+| link:#f[`f`] 
+| 
+| link:#g-0f[`g`] 
+| 
+| link:#h[`h`] 
+| 
+| link:#operator_not[`operator!`] 
+| Negation operator
+| link:#operator_eq[`operator&equals;&equals;`] 
+| Equality operator
+| link:#operator_not_eq[`operator!&equals;`] 
+| Inequality operator
+|===
+
+[#A]
+== A
+
+=== Synopsis
+
+Declared in `&lt;sort&hyphen;namespace&hyphen;members&hyphen;by&hyphen;name&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+struct A;
+----
+
+[#B-0b]
+== B
+
+=== Synopsis
+
+Declared in `&lt;sort&hyphen;namespace&hyphen;members&hyphen;by&hyphen;name&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+template&lt;
+    class T,
+    class U&gt;
+struct B;
+----
+
+[#B-04]
+== link:#B-0b[B]&lt;int, char&gt;
+
+=== Synopsis
+
+Declared in `&lt;sort&hyphen;namespace&hyphen;members&hyphen;by&hyphen;name&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+template&lt;&gt;
+struct link:#B-0b[B]&lt;int, char&gt;;
+----
+
+[#B-05]
+== link:#B-0b[B]&lt;int, U&gt;
+
+=== Synopsis
+
+Declared in `&lt;sort&hyphen;namespace&hyphen;members&hyphen;by&hyphen;name&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+template&lt;class U&gt;
+struct link:#B-0b[B]&lt;int, U&gt;;
+----
+
+[#C-0f]
+== C
+
+=== Synopsis
+
+Declared in `&lt;sort&hyphen;namespace&hyphen;members&hyphen;by&hyphen;name&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+template&lt;
+    class T,
+    class U = void&gt;
+struct C;
+----
+
+[#C-03]
+== link:#C-0f[C]&lt;int&gt;
+
+=== Synopsis
+
+Declared in `&lt;sort&hyphen;namespace&hyphen;members&hyphen;by&hyphen;name&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+template&lt;&gt;
+struct link:#C-0f[C]&lt;int&gt;;
+----
+
+[#C-0d]
+== link:#C-0f[C]&lt;int, char&gt;
+
+=== Synopsis
+
+Declared in `&lt;sort&hyphen;namespace&hyphen;members&hyphen;by&hyphen;name&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+template&lt;&gt;
+struct link:#C-0f[C]&lt;int, char&gt;;
+----
+
+[#D]
+== D
+
+=== Synopsis
+
+Declared in `&lt;sort&hyphen;namespace&hyphen;members&hyphen;by&hyphen;name&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+struct D;
+----
+
+[#Z]
+== Z
+
+=== Synopsis
+
+Declared in `&lt;sort&hyphen;namespace&hyphen;members&hyphen;by&hyphen;name&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+struct Z;
+----
+
+=== Member Functions
+
+[cols=2]
+|===
+| Name
+| Description
+| link:#Z-2constructor-00[`Z`]         [.small]#[constructor]#
+| Constructors
+| link:#Z-2destructor[`&#126;Z`] [.small]#[destructor]#
+| Destructor
+| link:#Z-foo[`foo`] 
+| 
+| link:#Z-2conversion[`operator bool`] 
+| Conversion to `bool`
+| link:#Z-operator_not[`operator!`] 
+| Negation operator
+| link:#Z-operator_eq[`operator&equals;&equals;`] 
+| Equality operator
+| link:#Z-operator_not_eq[`operator!&equals;`] 
+| Inequality operator
+| link:#Z-operator_3way[`operator&lt;&equals;&gt;`] 
+| Three&hyphen;way comparison operator
+|===
+
+[#Z-2constructor-00]
+== link:#Z[Z]::Z
+
+Constructors
+
+=== Synopses
+
+Declared in `&lt;sort&hyphen;namespace&hyphen;members&hyphen;by&hyphen;name&period;cpp&gt;`
+
+Default constructor
+
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+link:#Z-2constructor-05[Z]();
+----
+
+[.small]#link:#Z-2constructor-05[_» more&period;&period;&period;_]#
+
+Construct from `int`
+
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+link:#Z-2constructor-06[Z](int value);
+----
+
+[.small]#link:#Z-2constructor-06[_» more&period;&period;&period;_]#
+
+[#Z-2constructor-05]
+== link:#Z[Z]::Z
+
+Default constructor
+
+=== Synopsis
+
+Declared in `&lt;sort&hyphen;namespace&hyphen;members&hyphen;by&hyphen;name&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+Z();
+----
+
+[#Z-2constructor-06]
+== link:#Z[Z]::Z
+
+Construct from `int`
+
+=== Synopsis
+
+Declared in `&lt;sort&hyphen;namespace&hyphen;members&hyphen;by&hyphen;name&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+Z(int value);
+----
+
+=== Parameters
+
+[cols=2]
+|===
+| Name
+| Description
+| *value*
+| The value to construct from
+|===
+
+[#Z-2destructor]
+== link:#Z[Z]::&#126;Z
+
+Destructor
+
+=== Synopsis
+
+Declared in `&lt;sort&hyphen;namespace&hyphen;members&hyphen;by&hyphen;name&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+&#126;Z();
+----
+
+[#Z-foo]
+== link:#Z[Z]::foo
+
+=== Synopsis
+
+Declared in `&lt;sort&hyphen;namespace&hyphen;members&hyphen;by&hyphen;name&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+void
+foo() const;
+----
+
+[#Z-2conversion]
+== link:#Z[Z]::operator bool
+
+Conversion to `bool`
+
+=== Synopsis
+
+Declared in `&lt;sort&hyphen;namespace&hyphen;members&hyphen;by&hyphen;name&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+operator bool() const;
+----
+
+=== Return Value
+
+The object converted to `bool`
+
+[#Z-operator_not]
+== link:#Z[Z]::operator!
+
+Negation operator
+
+=== Synopsis
+
+Declared in `&lt;sort&hyphen;namespace&hyphen;members&hyphen;by&hyphen;name&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+bool
+operator!() const;
+----
+
+=== Return Value
+
+`true` if the object is falsy, `false` otherwise
+
+[#Z-operator_eq]
+== link:#Z[Z]::operator&equals;&equals;
+
+Equality operator
+
+=== Synopsis
+
+Declared in `&lt;sort&hyphen;namespace&hyphen;members&hyphen;by&hyphen;name&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+bool
+operator&equals;&equals;(link:#Z[Z] const& rhs) const;
+----
+
+=== Return Value
+
+`true` if the objects are equal, `false` otherwise
+
+=== Parameters
+
+[cols=2]
+|===
+| Name
+| Description
+| *rhs*
+| The right operand
+|===
+
+[#Z-operator_not_eq]
+== link:#Z[Z]::operator!&equals;
+
+Inequality operator
+
+=== Synopsis
+
+Declared in `&lt;sort&hyphen;namespace&hyphen;members&hyphen;by&hyphen;name&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+bool
+operator!&equals;(link:#Z[Z] const& rhs) const;
+----
+
+=== Return Value
+
+`true` if the objects are not equal, `false` otherwise
+
+=== Parameters
+
+[cols=2]
+|===
+| Name
+| Description
+| *rhs*
+| The right operand
+|===
+
+[#Z-operator_3way]
+== link:#Z[Z]::operator&lt;&equals;&gt;
+
+Three&hyphen;way comparison operator
+
+=== Synopsis
+
+Declared in `&lt;sort&hyphen;namespace&hyphen;members&hyphen;by&hyphen;name&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+auto
+operator&lt;&equals;&gt;(link:#Z[Z] const& rhs) const;
+----
+
+=== Return Value
+
+The relative order of the objects
+
+=== Parameters
+
+[cols=2]
+|===
+| Name
+| Description
+| *rhs*
+| The right operand
+|===
+
+[#f]
+== f
+
+=== Synopsis
+
+Declared in `&lt;sort&hyphen;namespace&hyphen;members&hyphen;by&hyphen;name&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+void
+f();
+----
+
+[#g-0f]
+== g
+
+=== Synopses
+
+Declared in `&lt;sort&hyphen;namespace&hyphen;members&hyphen;by&hyphen;name&period;cpp&gt;`
+
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+void
+link:#g-0e3[g]();
+----
+
+[.small]#link:#g-0e3[_» more&period;&period;&period;_]#
+
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+char
+link:#g-04[g](int);
+----
+
+[.small]#link:#g-04[_» more&period;&period;&period;_]#
+
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+char
+link:#g-06[g](double);
+----
+
+[.small]#link:#g-06[_» more&period;&period;&period;_]#
+
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+char
+link:#g-03a[g](
+    double,
+    char);
+----
+
+[.small]#link:#g-03a[_» more&period;&period;&period;_]#
+
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+char
+link:#g-0a[g](
+    char,
+    char,
+    char);
+----
+
+[.small]#link:#g-0a[_» more&period;&period;&period;_]#
+
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+template&lt;class T&gt;
+char
+link:#g-03c[g](
+    T,
+    T,
+    T);
+----
+
+[.small]#link:#g-03c[_» more&period;&period;&period;_]#
+
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+template&lt;&gt;
+char
+link:#g-0e4[g&lt;int&gt;](
+    int,
+    int,
+    int);
+----
+
+[.small]#link:#g-0e4[_» more&period;&period;&period;_]#
+
+[#g-0e3]
+== g
+
+=== Synopsis
+
+Declared in `&lt;sort&hyphen;namespace&hyphen;members&hyphen;by&hyphen;name&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+void
+g();
+----
+
+[#g-04]
+== g
+
+=== Synopsis
+
+Declared in `&lt;sort&hyphen;namespace&hyphen;members&hyphen;by&hyphen;name&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+char
+g(int);
+----
+
+[#g-06]
+== g
+
+=== Synopsis
+
+Declared in `&lt;sort&hyphen;namespace&hyphen;members&hyphen;by&hyphen;name&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+char
+g(double);
+----
+
+[#g-03a]
+== g
+
+=== Synopsis
+
+Declared in `&lt;sort&hyphen;namespace&hyphen;members&hyphen;by&hyphen;name&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+char
+g(
+    double,
+    char);
+----
+
+[#g-0a]
+== g
+
+=== Synopsis
+
+Declared in `&lt;sort&hyphen;namespace&hyphen;members&hyphen;by&hyphen;name&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+char
+g(
+    char,
+    char,
+    char);
+----
+
+[#g-03c]
+== g
+
+=== Synopsis
+
+Declared in `&lt;sort&hyphen;namespace&hyphen;members&hyphen;by&hyphen;name&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+template&lt;class T&gt;
+char
+g(
+    T,
+    T,
+    T);
+----
+
+[#g-0e4]
+== link:#g-03c[g]&lt;int&gt;
+
+=== Synopsis
+
+Declared in `&lt;sort&hyphen;namespace&hyphen;members&hyphen;by&hyphen;name&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+template&lt;&gt;
+char
+link:#g-03c[g]&lt;int&gt;(
+    int,
+    int,
+    int);
+----
+
+[#h]
+== h
+
+=== Synopsis
+
+Declared in `&lt;sort&hyphen;namespace&hyphen;members&hyphen;by&hyphen;name&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+void
+h();
+----
+
+[#operator_not]
+== operator!
+
+Negation operator
+
+=== Synopsis
+
+Declared in `&lt;sort&hyphen;namespace&hyphen;members&hyphen;by&hyphen;name&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+bool
+operator!(link:#A[A] const& v);
+----
+
+=== Return Value
+
+`true` if the object is falsy, `false` otherwise
+
+=== Parameters
+
+[cols=2]
+|===
+| Name
+| Description
+| *v*
+| The operand
+|===
+
+[#operator_eq]
+== operator&equals;&equals;
+
+Equality operator
+
+=== Synopsis
+
+Declared in `&lt;sort&hyphen;namespace&hyphen;members&hyphen;by&hyphen;name&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+bool
+operator&equals;&equals;(
+    link:#A[A] const& lhs,
+    link:#A[A] const& rhs);
+----
+
+=== Return Value
+
+`true` if the objects are equal, `false` otherwise
+
+=== Parameters
+
+[cols=2]
+|===
+| Name
+| Description
+| *lhs*
+| The left operand
+| *rhs*
+| The right operand
+|===
+
+[#operator_not_eq]
+== operator!&equals;
+
+Inequality operator
+
+=== Synopsis
+
+Declared in `&lt;sort&hyphen;namespace&hyphen;members&hyphen;by&hyphen;name&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+bool
+operator!&equals;(
+    link:#A[A] const& lhs,
+    link:#A[A] const& rhs);
+----
+
+=== Return Value
+
+`true` if the objects are not equal, `false` otherwise
+
+=== Parameters
+
+[cols=2]
+|===
+| Name
+| Description
+| *lhs*
+| The left operand
+| *rhs*
+| The right operand
+|===
+
+
+[.small]#Created with https://www.mrdocs.com[MrDocs]#

--- a/test-files/golden-tests/config/sort-namespace-members-by/sort-namespace-members-by-name.cpp
+++ b/test-files/golden-tests/config/sort-namespace-members-by/sort-namespace-members-by-name.cpp
@@ -1,0 +1,60 @@
+struct D {};
+
+template <class T, class U = void>
+struct C {};
+
+template <>
+struct C<int, char> {};
+
+template <>
+struct C<int> {};
+
+template <class T, class U>
+struct B {};
+
+template <>
+struct B<int, char> {};
+
+template <class U>
+struct B<int, U> {};
+
+struct A {};
+
+struct Z {
+    auto operator<=>(Z const&) const;
+    bool operator!=(Z const&) const;
+    bool operator==(Z const&) const;
+    bool operator!() const;
+    operator bool() const;
+    void foo() const;
+    ~Z();
+    Z(int);
+    Z();
+};
+
+bool operator!=(A const& lhs, A const& rhs);
+bool operator==(A const& lhs, A const& rhs);
+bool operator!(A const& v);
+
+void h();
+
+template <class T>
+char g(T, T, T);
+
+template <>
+char g<int>(int, int, int);
+
+char g(char, char, char);
+
+char g(double, char);
+
+char g(double);
+
+char g(int);
+
+char g(int);
+
+void g();
+
+void f();
+

--- a/test-files/golden-tests/config/sort-namespace-members-by/sort-namespace-members-by-name.html
+++ b/test-files/golden-tests/config/sort-namespace-members-by/sort-namespace-members-by-name.html
@@ -1,0 +1,904 @@
+<html lang="en">
+<head>
+<title>Reference</title>
+</head>
+<body>
+<div>
+<h1>Reference</h1>
+<div>
+<div>
+<h2 id="index"><a href="#index"></a></h2>
+</div>
+<h2>Types</h2>
+<table style="table-layout: fixed; width: 100%;">
+<thead>
+<tr>
+<th>Name</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a href="#A"><code>A</code></a> </td></tr><tr>
+<td><a href="#B-0b"><code>B</code></a> </td></tr><tr>
+<td><a href="#B-04"><code>B&lt;int, char&gt;</code></a> </td></tr><tr>
+<td><a href="#B-05"><code>B&lt;int, U&gt;</code></a> </td></tr><tr>
+<td><a href="#C-0f"><code>C</code></a> </td></tr><tr>
+<td><a href="#C-03"><code>C&lt;int&gt;</code></a> </td></tr><tr>
+<td><a href="#C-0d"><code>C&lt;int, char&gt;</code></a> </td></tr><tr>
+<td><a href="#D"><code>D</code></a> </td></tr><tr>
+<td><a href="#Z"><code>Z</code></a> </td></tr>
+</tbody>
+</table>
+
+<h2>Functions</h2>
+<table style="table-layout: fixed; width: 100%;">
+<thead>
+<tr>
+<th>Name</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a href="#f"><code>f</code></a> </td><td><span></span></td></tr><tr>
+<td><a href="#g-0f"><code>g</code></a> </td><td><span></span></td></tr><tr>
+<td><a href="#h"><code>h</code></a> </td><td><span></span></td></tr><tr>
+<td><a href="#operator_not"><code>operator!</code></a> </td><td><span>Negation operator</span></td></tr><tr>
+<td><a href="#operator_eq"><code>operator&#x3D;&#x3D;</code></a> </td><td><span>Equality operator</span></td></tr><tr>
+<td><a href="#operator_not_eq"><code>operator!&#x3D;</code></a> </td><td><span>Inequality operator</span></td></tr>
+</tbody>
+</table>
+
+</div>
+<div>
+<div>
+<h2 id="A"><a href="#A">A</a></h2>
+</div>
+<div>
+<h3>Synopsis</h3>
+<div>
+Declared in <code>&lt;sort-namespace-members-by-name.cpp&gt;</code></div>
+<pre>
+<code class="source-code cpp">struct A;
+
+</code>
+</pre>
+</div>
+
+
+</div>
+<div>
+<div>
+<h2 id="B-0b"><a href="#B-0b">B</a></h2>
+</div>
+<div>
+<h3>Synopsis</h3>
+<div>
+Declared in <code>&lt;sort-namespace-members-by-name.cpp&gt;</code></div>
+<pre>
+<code class="source-code cpp">template&lt;
+    class T,
+    class U&gt;
+struct B;
+
+</code>
+</pre>
+</div>
+
+
+</div>
+<div>
+<div>
+<h2 id="B-04"><a href="#B-04">B&lt;int, char&gt;</a></h2>
+</div>
+<div>
+<h3>Synopsis</h3>
+<div>
+Declared in <code>&lt;sort-namespace-members-by-name.cpp&gt;</code></div>
+<pre>
+<code class="source-code cpp">template&lt;&gt;
+struct <a href="#B-0b">B</a>&lt;int, char&gt;;
+
+</code>
+</pre>
+</div>
+
+
+</div>
+<div>
+<div>
+<h2 id="B-05"><a href="#B-05">B&lt;int, U&gt;</a></h2>
+</div>
+<div>
+<h3>Synopsis</h3>
+<div>
+Declared in <code>&lt;sort-namespace-members-by-name.cpp&gt;</code></div>
+<pre>
+<code class="source-code cpp">template&lt;class U&gt;
+struct <a href="#B-0b">B</a>&lt;int, U&gt;;
+
+</code>
+</pre>
+</div>
+
+
+</div>
+<div>
+<div>
+<h2 id="C-0f"><a href="#C-0f">C</a></h2>
+</div>
+<div>
+<h3>Synopsis</h3>
+<div>
+Declared in <code>&lt;sort-namespace-members-by-name.cpp&gt;</code></div>
+<pre>
+<code class="source-code cpp">template&lt;
+    class T,
+    class U = void&gt;
+struct C;
+
+</code>
+</pre>
+</div>
+
+
+</div>
+<div>
+<div>
+<h2 id="C-03"><a href="#C-03">C&lt;int&gt;</a></h2>
+</div>
+<div>
+<h3>Synopsis</h3>
+<div>
+Declared in <code>&lt;sort-namespace-members-by-name.cpp&gt;</code></div>
+<pre>
+<code class="source-code cpp">template&lt;&gt;
+struct <a href="#C-0f">C</a>&lt;int&gt;;
+
+</code>
+</pre>
+</div>
+
+
+</div>
+<div>
+<div>
+<h2 id="C-0d"><a href="#C-0d">C&lt;int, char&gt;</a></h2>
+</div>
+<div>
+<h3>Synopsis</h3>
+<div>
+Declared in <code>&lt;sort-namespace-members-by-name.cpp&gt;</code></div>
+<pre>
+<code class="source-code cpp">template&lt;&gt;
+struct <a href="#C-0f">C</a>&lt;int, char&gt;;
+
+</code>
+</pre>
+</div>
+
+
+</div>
+<div>
+<div>
+<h2 id="D"><a href="#D">D</a></h2>
+</div>
+<div>
+<h3>Synopsis</h3>
+<div>
+Declared in <code>&lt;sort-namespace-members-by-name.cpp&gt;</code></div>
+<pre>
+<code class="source-code cpp">struct D;
+
+</code>
+</pre>
+</div>
+
+
+</div>
+<div>
+<div>
+<h2 id="Z"><a href="#Z">Z</a></h2>
+</div>
+<div>
+<h3>Synopsis</h3>
+<div>
+Declared in <code>&lt;sort-namespace-members-by-name.cpp&gt;</code></div>
+<pre>
+<code class="source-code cpp">struct Z;
+
+</code>
+</pre>
+</div>
+<h2>Member Functions</h2>
+<table style="table-layout: fixed; width: 100%;">
+<thead>
+<tr>
+<th>Name</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a href="#Z-2constructor-00"><code>Z</code></a>         <span class="small">[constructor]</span></td><td><span>Constructors</span></td></tr><tr>
+<td><a href="#Z-2destructor"><code>~Z</code></a> <span class="small">[destructor]</span></td><td><span>Destructor</span></td></tr><tr>
+<td><a href="#Z-foo"><code>foo</code></a> </td><td><span></span></td></tr><tr>
+<td><a href="#Z-2conversion"><code>operator bool</code></a> </td><td><span>Conversion to <code>bool</code></span></td></tr><tr>
+<td><a href="#Z-operator_not"><code>operator!</code></a> </td><td><span>Negation operator</span></td></tr><tr>
+<td><a href="#Z-operator_eq"><code>operator&#x3D;&#x3D;</code></a> </td><td><span>Equality operator</span></td></tr><tr>
+<td><a href="#Z-operator_not_eq"><code>operator!&#x3D;</code></a> </td><td><span>Inequality operator</span></td></tr><tr>
+<td><a href="#Z-operator_3way"><code>operator&lt;&#x3D;&gt;</code></a> </td><td><span>Three-way comparison operator</span></td></tr>
+</tbody>
+</table>
+
+
+
+</div>
+<div>
+<div>
+<h2 id="Z-2constructor-00"><a href="#Z-2constructor-00">Z::Z</a></h2>
+<div>
+<span>Constructors</span>
+
+</div>
+</div>
+<div>
+<h3>Synopses</h3>
+<div>
+Declared in <code>&lt;sort-namespace-members-by-name.cpp&gt;</code></div>
+<span>Default constructor</span>
+<pre>
+<code class="source-code cpp"><a href="#Z-2constructor-05">Z</a>();
+
+</code>
+</pre><span class="small"><a href="#Z-2constructor-05"><em>» more...</em></a></span>
+
+<span>Construct from <code>int</code></span>
+<pre>
+<code class="source-code cpp"><a href="#Z-2constructor-06">Z</a>(int value);
+
+</code>
+</pre><span class="small"><a href="#Z-2constructor-06"><em>» more...</em></a></span>
+
+
+</div>
+</div>
+<div>
+<div>
+<h2 id="Z-2constructor-05"><a href="#Z-2constructor-05">Z::Z</a></h2>
+<div>
+<span>Default constructor</span>
+
+</div>
+</div>
+<div>
+<h3>Synopsis</h3>
+<div>
+Declared in <code>&lt;sort-namespace-members-by-name.cpp&gt;</code></div>
+<pre>
+<code class="source-code cpp">Z();
+
+</code>
+</pre>
+</div>
+</div>
+<div>
+<div>
+<h2 id="Z-2constructor-06"><a href="#Z-2constructor-06">Z::Z</a></h2>
+<div>
+<span>Construct from <code>int</code></span>
+
+</div>
+</div>
+<div>
+<h3>Synopsis</h3>
+<div>
+Declared in <code>&lt;sort-namespace-members-by-name.cpp&gt;</code></div>
+<pre>
+<code class="source-code cpp">Z(int value);
+
+</code>
+</pre>
+</div>
+<div>
+<h3>Parameters</h3>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>value</strong></td>
+<td><span>The value to construct from</span></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div>
+<div>
+<h2 id="Z-2destructor"><a href="#Z-2destructor">Z::~Z</a></h2>
+<div>
+<span>Destructor</span>
+
+</div>
+</div>
+<div>
+<h3>Synopsis</h3>
+<div>
+Declared in <code>&lt;sort-namespace-members-by-name.cpp&gt;</code></div>
+<pre>
+<code class="source-code cpp">~Z();
+
+</code>
+</pre>
+</div>
+</div>
+<div>
+<div>
+<h2 id="Z-foo"><a href="#Z-foo">Z::foo</a></h2>
+</div>
+<div>
+<h3>Synopsis</h3>
+<div>
+Declared in <code>&lt;sort-namespace-members-by-name.cpp&gt;</code></div>
+<pre>
+<code class="source-code cpp">void
+foo() const;
+
+</code>
+</pre>
+</div>
+</div>
+<div>
+<div>
+<h2 id="Z-2conversion"><a href="#Z-2conversion">Z::operator bool</a></h2>
+<div>
+<span>Conversion to <code>bool</code></span>
+
+</div>
+</div>
+<div>
+<h3>Synopsis</h3>
+<div>
+Declared in <code>&lt;sort-namespace-members-by-name.cpp&gt;</code></div>
+<pre>
+<code class="source-code cpp">operator bool() const;
+
+</code>
+</pre>
+</div>
+<div>
+<h3>Return Value</h3>
+<span>The object converted to <code>bool</code></span>
+</div>
+</div>
+<div>
+<div>
+<h2 id="Z-operator_not"><a href="#Z-operator_not">Z::operator!</a></h2>
+<div>
+<span>Negation operator</span>
+
+</div>
+</div>
+<div>
+<h3>Synopsis</h3>
+<div>
+Declared in <code>&lt;sort-namespace-members-by-name.cpp&gt;</code></div>
+<pre>
+<code class="source-code cpp">bool
+operator!() const;
+
+</code>
+</pre>
+</div>
+<div>
+<h3>Return Value</h3>
+<span><code>true</code> if the object is falsy, <code>false</code> otherwise</span>
+</div>
+</div>
+<div>
+<div>
+<h2 id="Z-operator_eq"><a href="#Z-operator_eq">Z::operator&#x3D;&#x3D;</a></h2>
+<div>
+<span>Equality operator</span>
+
+</div>
+</div>
+<div>
+<h3>Synopsis</h3>
+<div>
+Declared in <code>&lt;sort-namespace-members-by-name.cpp&gt;</code></div>
+<pre>
+<code class="source-code cpp">bool
+operator&#x3D;&#x3D;(<a href="#Z">Z</a> const& rhs) const;
+
+</code>
+</pre>
+</div>
+<div>
+<h3>Return Value</h3>
+<span><code>true</code> if the objects are equal, <code>false</code> otherwise</span>
+</div>
+<div>
+<h3>Parameters</h3>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>rhs</strong></td>
+<td><span>The right operand</span></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div>
+<div>
+<h2 id="Z-operator_not_eq"><a href="#Z-operator_not_eq">Z::operator!&#x3D;</a></h2>
+<div>
+<span>Inequality operator</span>
+
+</div>
+</div>
+<div>
+<h3>Synopsis</h3>
+<div>
+Declared in <code>&lt;sort-namespace-members-by-name.cpp&gt;</code></div>
+<pre>
+<code class="source-code cpp">bool
+operator!&#x3D;(<a href="#Z">Z</a> const& rhs) const;
+
+</code>
+</pre>
+</div>
+<div>
+<h3>Return Value</h3>
+<span><code>true</code> if the objects are not equal, <code>false</code> otherwise</span>
+</div>
+<div>
+<h3>Parameters</h3>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>rhs</strong></td>
+<td><span>The right operand</span></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div>
+<div>
+<h2 id="Z-operator_3way"><a href="#Z-operator_3way">Z::operator&lt;&#x3D;&gt;</a></h2>
+<div>
+<span>Three-way comparison operator</span>
+
+</div>
+</div>
+<div>
+<h3>Synopsis</h3>
+<div>
+Declared in <code>&lt;sort-namespace-members-by-name.cpp&gt;</code></div>
+<pre>
+<code class="source-code cpp">auto
+operator&lt;&#x3D;&gt;(<a href="#Z">Z</a> const& rhs) const;
+
+</code>
+</pre>
+</div>
+<div>
+<h3>Return Value</h3>
+<span>The relative order of the objects</span>
+</div>
+<div>
+<h3>Parameters</h3>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>rhs</strong></td>
+<td><span>The right operand</span></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div>
+<div>
+<h2 id="f"><a href="#f">f</a></h2>
+</div>
+<div>
+<h3>Synopsis</h3>
+<div>
+Declared in <code>&lt;sort-namespace-members-by-name.cpp&gt;</code></div>
+<pre>
+<code class="source-code cpp">void
+f();
+
+</code>
+</pre>
+</div>
+</div>
+<div>
+<div>
+<h2 id="g-0f"><a href="#g-0f">g</a></h2>
+</div>
+<div>
+<h3>Synopses</h3>
+<div>
+Declared in <code>&lt;sort-namespace-members-by-name.cpp&gt;</code></div>
+
+<pre>
+<code class="source-code cpp">void
+<a href="#g-0e3">g</a>();
+
+</code>
+</pre><span class="small"><a href="#g-0e3"><em>» more...</em></a></span>
+
+
+<pre>
+<code class="source-code cpp">char
+<a href="#g-04">g</a>(int);
+
+</code>
+</pre><span class="small"><a href="#g-04"><em>» more...</em></a></span>
+
+
+<pre>
+<code class="source-code cpp">char
+<a href="#g-06">g</a>(double);
+
+</code>
+</pre><span class="small"><a href="#g-06"><em>» more...</em></a></span>
+
+
+<pre>
+<code class="source-code cpp">char
+<a href="#g-03a">g</a>(
+    double,
+    char);
+
+</code>
+</pre><span class="small"><a href="#g-03a"><em>» more...</em></a></span>
+
+
+<pre>
+<code class="source-code cpp">char
+<a href="#g-0a">g</a>(
+    char,
+    char,
+    char);
+
+</code>
+</pre><span class="small"><a href="#g-0a"><em>» more...</em></a></span>
+
+
+<pre>
+<code class="source-code cpp">template&lt;class T&gt;
+char
+<a href="#g-03c">g</a>(
+    T,
+    T,
+    T);
+
+</code>
+</pre><span class="small"><a href="#g-03c"><em>» more...</em></a></span>
+
+
+<pre>
+<code class="source-code cpp">template&lt;&gt;
+char
+<a href="#g-0e4">g&lt;int&gt;</a>(
+    int,
+    int,
+    int);
+
+</code>
+</pre><span class="small"><a href="#g-0e4"><em>» more...</em></a></span>
+
+
+</div>
+</div>
+<div>
+<div>
+<h2 id="g-0e3"><a href="#g-0e3">g</a></h2>
+</div>
+<div>
+<h3>Synopsis</h3>
+<div>
+Declared in <code>&lt;sort-namespace-members-by-name.cpp&gt;</code></div>
+<pre>
+<code class="source-code cpp">void
+g();
+
+</code>
+</pre>
+</div>
+</div>
+<div>
+<div>
+<h2 id="g-04"><a href="#g-04">g</a></h2>
+</div>
+<div>
+<h3>Synopsis</h3>
+<div>
+Declared in <code>&lt;sort-namespace-members-by-name.cpp&gt;</code></div>
+<pre>
+<code class="source-code cpp">char
+g(int);
+
+</code>
+</pre>
+</div>
+</div>
+<div>
+<div>
+<h2 id="g-06"><a href="#g-06">g</a></h2>
+</div>
+<div>
+<h3>Synopsis</h3>
+<div>
+Declared in <code>&lt;sort-namespace-members-by-name.cpp&gt;</code></div>
+<pre>
+<code class="source-code cpp">char
+g(double);
+
+</code>
+</pre>
+</div>
+</div>
+<div>
+<div>
+<h2 id="g-03a"><a href="#g-03a">g</a></h2>
+</div>
+<div>
+<h3>Synopsis</h3>
+<div>
+Declared in <code>&lt;sort-namespace-members-by-name.cpp&gt;</code></div>
+<pre>
+<code class="source-code cpp">char
+g(
+    double,
+    char);
+
+</code>
+</pre>
+</div>
+</div>
+<div>
+<div>
+<h2 id="g-0a"><a href="#g-0a">g</a></h2>
+</div>
+<div>
+<h3>Synopsis</h3>
+<div>
+Declared in <code>&lt;sort-namespace-members-by-name.cpp&gt;</code></div>
+<pre>
+<code class="source-code cpp">char
+g(
+    char,
+    char,
+    char);
+
+</code>
+</pre>
+</div>
+</div>
+<div>
+<div>
+<h2 id="g-03c"><a href="#g-03c">g</a></h2>
+</div>
+<div>
+<h3>Synopsis</h3>
+<div>
+Declared in <code>&lt;sort-namespace-members-by-name.cpp&gt;</code></div>
+<pre>
+<code class="source-code cpp">template&lt;class T&gt;
+char
+g(
+    T,
+    T,
+    T);
+
+</code>
+</pre>
+</div>
+</div>
+<div>
+<div>
+<h2 id="g-0e4"><a href="#g-0e4">g&lt;int&gt;</a></h2>
+</div>
+<div>
+<h3>Synopsis</h3>
+<div>
+Declared in <code>&lt;sort-namespace-members-by-name.cpp&gt;</code></div>
+<pre>
+<code class="source-code cpp">template&lt;&gt;
+char
+<a href="#g-03c">g</a>&lt;int&gt;(
+    int,
+    int,
+    int);
+
+</code>
+</pre>
+</div>
+</div>
+<div>
+<div>
+<h2 id="h"><a href="#h">h</a></h2>
+</div>
+<div>
+<h3>Synopsis</h3>
+<div>
+Declared in <code>&lt;sort-namespace-members-by-name.cpp&gt;</code></div>
+<pre>
+<code class="source-code cpp">void
+h();
+
+</code>
+</pre>
+</div>
+</div>
+<div>
+<div>
+<h2 id="operator_not"><a href="#operator_not">operator!</a></h2>
+<div>
+<span>Negation operator</span>
+
+</div>
+</div>
+<div>
+<h3>Synopsis</h3>
+<div>
+Declared in <code>&lt;sort-namespace-members-by-name.cpp&gt;</code></div>
+<pre>
+<code class="source-code cpp">bool
+operator!(<a href="#A">A</a> const& v);
+
+</code>
+</pre>
+</div>
+<div>
+<h3>Return Value</h3>
+<span><code>true</code> if the object is falsy, <code>false</code> otherwise</span>
+</div>
+<div>
+<h3>Parameters</h3>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>v</strong></td>
+<td><span>The operand</span></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div>
+<div>
+<h2 id="operator_eq"><a href="#operator_eq">operator&#x3D;&#x3D;</a></h2>
+<div>
+<span>Equality operator</span>
+
+</div>
+</div>
+<div>
+<h3>Synopsis</h3>
+<div>
+Declared in <code>&lt;sort-namespace-members-by-name.cpp&gt;</code></div>
+<pre>
+<code class="source-code cpp">bool
+operator&#x3D;&#x3D;(
+    <a href="#A">A</a> const& lhs,
+    <a href="#A">A</a> const& rhs);
+
+</code>
+</pre>
+</div>
+<div>
+<h3>Return Value</h3>
+<span><code>true</code> if the objects are equal, <code>false</code> otherwise</span>
+</div>
+<div>
+<h3>Parameters</h3>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>lhs</strong></td>
+<td><span>The left operand</span></td>
+</tr>
+<tr>
+<td><strong>rhs</strong></td>
+<td><span>The right operand</span></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div>
+<div>
+<h2 id="operator_not_eq"><a href="#operator_not_eq">operator!&#x3D;</a></h2>
+<div>
+<span>Inequality operator</span>
+
+</div>
+</div>
+<div>
+<h3>Synopsis</h3>
+<div>
+Declared in <code>&lt;sort-namespace-members-by-name.cpp&gt;</code></div>
+<pre>
+<code class="source-code cpp">bool
+operator!&#x3D;(
+    <a href="#A">A</a> const& lhs,
+    <a href="#A">A</a> const& rhs);
+
+</code>
+</pre>
+</div>
+<div>
+<h3>Return Value</h3>
+<span><code>true</code> if the objects are not equal, <code>false</code> otherwise</span>
+</div>
+<div>
+<h3>Parameters</h3>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>lhs</strong></td>
+<td><span>The left operand</span></td>
+</tr>
+<tr>
+<td><strong>rhs</strong></td>
+<td><span>The right operand</span></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+
+</div>
+<div>
+<h4>Created with <a href="https://www.mrdocs.com">MrDocs</a></h4>
+</div>
+</body>
+</html>

--- a/test-files/golden-tests/config/sort-namespace-members-by/sort-namespace-members-by-name.xml
+++ b/test-files/golden-tests/config/sort-namespace-members-by/sort-namespace-members-by-name.xml
@@ -1,0 +1,392 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mrdocs xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="https://github.com/cppalliance/mrdocs/raw/develop/mrdocs.rnc">
+<namespace id="//////////////////////////8=">
+  <struct name="A" id="YrPSaKAbmXgzCAX5WByx4eVoqBM=">
+    <file short-path="sort-namespace-members-by-name.cpp" source-path="sort-namespace-members-by-name.cpp" line="21" class="def"/>
+  </struct>
+  <template>
+    <tparam name="T" class="type"/>
+    <tparam name="U" class="type"/>
+    <struct name="B" id="swBEqeWAJoaWVKty+1lCoYUK04A=">
+      <file short-path="sort-namespace-members-by-name.cpp" source-path="sort-namespace-members-by-name.cpp" line="12" class="def"/>
+    </struct>
+  </template>
+  <template class="explicit" id="swBEqeWAJoaWVKty+1lCoYUK04A=">
+    <targ class="type" type="int"/>
+    <targ class="type" type="char"/>
+    <struct name="B" id="S+FvHbXPEwSCkNHoe9TC9L5a4Yk=">
+      <file short-path="sort-namespace-members-by-name.cpp" source-path="sort-namespace-members-by-name.cpp" line="16" class="def"/>
+    </struct>
+  </template>
+  <template class="partial" id="swBEqeWAJoaWVKty+1lCoYUK04A=">
+    <tparam name="U" class="type"/>
+    <targ class="type" type="int"/>
+    <targ class="type" type="U"/>
+    <struct name="B" id="VwFE3CILPejPf11zTv20aat7w8Q=">
+      <file short-path="sort-namespace-members-by-name.cpp" source-path="sort-namespace-members-by-name.cpp" line="19" class="def"/>
+    </struct>
+  </template>
+  <template>
+    <tparam name="T" class="type"/>
+    <tparam name="U" class="type" default="void"/>
+    <struct name="C" id="8nYw0KA23eAszqSOs0wOXAD1DYQ=">
+      <file short-path="sort-namespace-members-by-name.cpp" source-path="sort-namespace-members-by-name.cpp" line="3" class="def"/>
+    </struct>
+  </template>
+  <template class="explicit" id="8nYw0KA23eAszqSOs0wOXAD1DYQ=">
+    <targ class="type" type="int"/>
+    <struct name="C" id="NLoLTepRVq6Wm8kqUGSEoM03TKg=">
+      <file short-path="sort-namespace-members-by-name.cpp" source-path="sort-namespace-members-by-name.cpp" line="10" class="def"/>
+    </struct>
+  </template>
+  <template class="explicit" id="8nYw0KA23eAszqSOs0wOXAD1DYQ=">
+    <targ class="type" type="int"/>
+    <targ class="type" type="char"/>
+    <struct name="C" id="1gG5jFtdo9Wauh4eNKJFnssDpFU=">
+      <file short-path="sort-namespace-members-by-name.cpp" source-path="sort-namespace-members-by-name.cpp" line="7" class="def"/>
+    </struct>
+  </template>
+  <struct name="D" id="CSFzdUEgi4+pu0K2D3isHXeaoFQ=">
+    <file short-path="sort-namespace-members-by-name.cpp" source-path="sort-namespace-members-by-name.cpp" line="1" class="def"/>
+  </struct>
+  <struct name="Z" id="NQ8uQgTcafPcttyBMHHLHAXA4MA=">
+    <file short-path="sort-namespace-members-by-name.cpp" source-path="sort-namespace-members-by-name.cpp" line="23" class="def"/>
+    <function class="constructor" name="Z" id="WltomC+2IcmzMN0COGL0OWWmbZk=">
+      <file short-path="sort-namespace-members-by-name.cpp" source-path="sort-namespace-members-by-name.cpp" line="32"/>
+      <doc>
+        <brief>
+          <text>Default constructor</text>
+        </brief>
+      </doc>
+    </function>
+    <function class="constructor" name="Z" id="aQWtFVa4Xa+eceLXiLW74q44JRk=">
+      <file short-path="sort-namespace-members-by-name.cpp" source-path="sort-namespace-members-by-name.cpp" line="31"/>
+      <param name="value">
+        <type name="int"/>
+      </param>
+      <doc>
+        <brief>
+          <text>Construct from </text>
+          <mono>int</mono>
+        </brief>
+        <param name="value">
+          <text>The value to construct from</text>
+        </param>
+      </doc>
+    </function>
+    <function class="destructor" name="~Z" id="HMG56OCQ5OpB2E9hu4bG3/hoOho=">
+      <file short-path="sort-namespace-members-by-name.cpp" source-path="sort-namespace-members-by-name.cpp" line="30"/>
+      <doc>
+        <brief>
+          <text>Destructor</text>
+        </brief>
+      </doc>
+    </function>
+    <function name="foo" id="lBA1besl9J3wAZAcEn9C+K05hf4=">
+      <file short-path="sort-namespace-members-by-name.cpp" source-path="sort-namespace-members-by-name.cpp" line="29"/>
+      <attr id="is-const"/>
+    </function>
+    <function class="conversion" name="operator bool" id="zQ0DYAZMF+xhfbo8hUyqZRNKJ+U=">
+      <file short-path="sort-namespace-members-by-name.cpp" source-path="sort-namespace-members-by-name.cpp" line="28"/>
+      <attr id="is-const"/>
+      <return>
+        <type name="bool"/>
+      </return>
+      <doc>
+        <brief>
+          <text>Conversion to </text>
+          <mono>bool</mono>
+        </brief>
+        <returns>
+          <text>The object converted to </text>
+          <mono>bool</mono>
+        </returns>
+      </doc>
+    </function>
+    <function name="operator!" id="rjPdhFxUkaC43tWXi+kka78JQxI=">
+      <file short-path="sort-namespace-members-by-name.cpp" source-path="sort-namespace-members-by-name.cpp" line="27"/>
+      <attr id="operator" name="not" value="27"/>
+      <attr id="is-const"/>
+      <return>
+        <type name="bool"/>
+      </return>
+      <doc>
+        <brief>
+          <text>Negation operator</text>
+        </brief>
+        <returns>
+          <mono>true</mono>
+          <text> if the object is falsy, </text>
+          <mono>false</mono>
+          <text> otherwise</text>
+        </returns>
+      </doc>
+    </function>
+    <function name="operator==" id="atwUGLD+QHVhH3x1+8qzINNxzMY=">
+      <file short-path="sort-namespace-members-by-name.cpp" source-path="sort-namespace-members-by-name.cpp" line="26"/>
+      <attr id="operator" name="eq" value="28"/>
+      <attr id="is-const"/>
+      <return>
+        <type name="bool"/>
+      </return>
+      <param name="rhs">
+        <type class="lvalue-reference">
+          <pointee-type id="NQ8uQgTcafPcttyBMHHLHAXA4MA=" name="Z" cv-qualifiers="const"/>
+        </type>
+      </param>
+      <doc>
+        <brief>
+          <text>Equality operator</text>
+        </brief>
+        <returns>
+          <mono>true</mono>
+          <text> if the objects are equal, </text>
+          <mono>false</mono>
+          <text> otherwise</text>
+        </returns>
+        <param name="rhs">
+          <text>The right operand</text>
+        </param>
+      </doc>
+    </function>
+    <function name="operator!=" id="CB0pXrzU8BKZ2LF0BSpclxIfgrs=">
+      <file short-path="sort-namespace-members-by-name.cpp" source-path="sort-namespace-members-by-name.cpp" line="25"/>
+      <attr id="operator" name="not_eq" value="29"/>
+      <attr id="is-const"/>
+      <return>
+        <type name="bool"/>
+      </return>
+      <param name="rhs">
+        <type class="lvalue-reference">
+          <pointee-type id="NQ8uQgTcafPcttyBMHHLHAXA4MA=" name="Z" cv-qualifiers="const"/>
+        </type>
+      </param>
+      <doc>
+        <brief>
+          <text>Inequality operator</text>
+        </brief>
+        <returns>
+          <mono>true</mono>
+          <text> if the objects are not equal, </text>
+          <mono>false</mono>
+          <text> otherwise</text>
+        </returns>
+        <param name="rhs">
+          <text>The right operand</text>
+        </param>
+      </doc>
+    </function>
+    <function name="operator&lt;=&gt;" id="6/NYLeQdPqWrbu5kHnTpE3u6Yg4=">
+      <file short-path="sort-namespace-members-by-name.cpp" source-path="sort-namespace-members-by-name.cpp" line="24"/>
+      <attr id="operator" name="3way" value="34"/>
+      <attr id="is-const"/>
+      <return>
+        <type class="auto" keyword="auto">
+        </type>
+      </return>
+      <param name="rhs">
+        <type class="lvalue-reference">
+          <pointee-type id="NQ8uQgTcafPcttyBMHHLHAXA4MA=" name="Z" cv-qualifiers="const"/>
+        </type>
+      </param>
+      <doc>
+        <brief>
+          <text>Three-way comparison operator</text>
+        </brief>
+        <returns>
+          <text>The relative order of the objects</text>
+        </returns>
+        <param name="rhs">
+          <text>The right operand</text>
+        </param>
+      </doc>
+    </function>
+  </struct>
+  <function name="f" id="s6nsa+zVhpzzrN+yUVPP5rvdXqs=">
+    <file short-path="sort-namespace-members-by-name.cpp" source-path="sort-namespace-members-by-name.cpp" line="59"/>
+  </function>
+  <function name="g" id="43ASI/aC9fCLy8T+1gn7pUdis+g=">
+    <file short-path="sort-namespace-members-by-name.cpp" source-path="sort-namespace-members-by-name.cpp" line="57"/>
+  </function>
+  <function name="g" id="SvF6a1ZP8sdIXexPrrRDIA1OHus=">
+    <file short-path="sort-namespace-members-by-name.cpp" source-path="sort-namespace-members-by-name.cpp" line="53"/>
+    <file short-path="sort-namespace-members-by-name.cpp" source-path="sort-namespace-members-by-name.cpp" line="55"/>
+    <return>
+      <type name="char"/>
+    </return>
+    <param>
+      <type name="int"/>
+    </param>
+  </function>
+  <function name="g" id="ZYC+YG/hWLHomKHwEAfoO4TO2cw=">
+    <file short-path="sort-namespace-members-by-name.cpp" source-path="sort-namespace-members-by-name.cpp" line="51"/>
+    <return>
+      <type name="char"/>
+    </return>
+    <param>
+      <type name="double"/>
+    </param>
+  </function>
+  <function name="g" id="OqSPxlq/89fBNIHVGkd2KTtgheY=">
+    <file short-path="sort-namespace-members-by-name.cpp" source-path="sort-namespace-members-by-name.cpp" line="49"/>
+    <return>
+      <type name="char"/>
+    </return>
+    <param>
+      <type name="double"/>
+    </param>
+    <param>
+      <type name="char"/>
+    </param>
+  </function>
+  <function name="g" id="rs6F2A6K2Qvx34WDTz9fCKP4+HE=">
+    <file short-path="sort-namespace-members-by-name.cpp" source-path="sort-namespace-members-by-name.cpp" line="47"/>
+    <return>
+      <type name="char"/>
+    </return>
+    <param>
+      <type name="char"/>
+    </param>
+    <param>
+      <type name="char"/>
+    </param>
+    <param>
+      <type name="char"/>
+    </param>
+  </function>
+  <template>
+    <tparam name="T" class="type"/>
+    <function name="g" id="PEedgXj8uxMWKd/yZk6yqAz6boU=">
+      <file short-path="sort-namespace-members-by-name.cpp" source-path="sort-namespace-members-by-name.cpp" line="41"/>
+      <return>
+        <type name="char"/>
+      </return>
+      <param>
+        <type name="T"/>
+      </param>
+      <param>
+        <type name="T"/>
+      </param>
+      <param>
+        <type name="T"/>
+      </param>
+    </function>
+  </template>
+  <template class="explicit" id="PEedgXj8uxMWKd/yZk6yqAz6boU=">
+    <targ class="type" type="int"/>
+    <function name="g" id="5LjM4cXZ7IywLIZW1RtfpP7tNNk=">
+      <file short-path="sort-namespace-members-by-name.cpp" source-path="sort-namespace-members-by-name.cpp" line="44"/>
+      <return>
+        <type name="char"/>
+      </return>
+      <param>
+        <type name="int"/>
+      </param>
+      <param>
+        <type name="int"/>
+      </param>
+      <param>
+        <type name="int"/>
+      </param>
+    </function>
+  </template>
+  <function name="h" id="rvT6OxIrrSI0KxJ2nkfEgBz/Lz4=">
+    <file short-path="sort-namespace-members-by-name.cpp" source-path="sort-namespace-members-by-name.cpp" line="39"/>
+  </function>
+  <function name="operator!" id="yuKyBhGbND+Kyypyb9UsuC4Qe3E=">
+    <file short-path="sort-namespace-members-by-name.cpp" source-path="sort-namespace-members-by-name.cpp" line="37"/>
+    <attr id="operator" name="not" value="27"/>
+    <return>
+      <type name="bool"/>
+    </return>
+    <param name="v">
+      <type class="lvalue-reference">
+        <pointee-type id="YrPSaKAbmXgzCAX5WByx4eVoqBM=" name="A" cv-qualifiers="const"/>
+      </type>
+    </param>
+    <doc>
+      <brief>
+        <text>Negation operator</text>
+      </brief>
+      <returns>
+        <mono>true</mono>
+        <text> if the object is falsy, </text>
+        <mono>false</mono>
+        <text> otherwise</text>
+      </returns>
+      <param name="v">
+        <text>The operand</text>
+      </param>
+    </doc>
+  </function>
+  <function name="operator==" id="kibUx6k1SXB+HsXkRXroJl9f59w=">
+    <file short-path="sort-namespace-members-by-name.cpp" source-path="sort-namespace-members-by-name.cpp" line="36"/>
+    <attr id="operator" name="eq" value="28"/>
+    <return>
+      <type name="bool"/>
+    </return>
+    <param name="lhs">
+      <type class="lvalue-reference">
+        <pointee-type id="YrPSaKAbmXgzCAX5WByx4eVoqBM=" name="A" cv-qualifiers="const"/>
+      </type>
+    </param>
+    <param name="rhs">
+      <type class="lvalue-reference">
+        <pointee-type id="YrPSaKAbmXgzCAX5WByx4eVoqBM=" name="A" cv-qualifiers="const"/>
+      </type>
+    </param>
+    <doc>
+      <brief>
+        <text>Equality operator</text>
+      </brief>
+      <returns>
+        <mono>true</mono>
+        <text> if the objects are equal, </text>
+        <mono>false</mono>
+        <text> otherwise</text>
+      </returns>
+      <param name="lhs">
+        <text>The left operand</text>
+      </param>
+      <param name="rhs">
+        <text>The right operand</text>
+      </param>
+    </doc>
+  </function>
+  <function name="operator!=" id="4MuN1V3fHVfOMvtg2LT+QVm/XmE=">
+    <file short-path="sort-namespace-members-by-name.cpp" source-path="sort-namespace-members-by-name.cpp" line="35"/>
+    <attr id="operator" name="not_eq" value="29"/>
+    <return>
+      <type name="bool"/>
+    </return>
+    <param name="lhs">
+      <type class="lvalue-reference">
+        <pointee-type id="YrPSaKAbmXgzCAX5WByx4eVoqBM=" name="A" cv-qualifiers="const"/>
+      </type>
+    </param>
+    <param name="rhs">
+      <type class="lvalue-reference">
+        <pointee-type id="YrPSaKAbmXgzCAX5WByx4eVoqBM=" name="A" cv-qualifiers="const"/>
+      </type>
+    </param>
+    <doc>
+      <brief>
+        <text>Inequality operator</text>
+      </brief>
+      <returns>
+        <mono>true</mono>
+        <text> if the objects are not equal, </text>
+        <mono>false</mono>
+        <text> otherwise</text>
+      </returns>
+      <param name="lhs">
+        <text>The left operand</text>
+      </param>
+      <param name="rhs">
+        <text>The right operand</text>
+      </param>
+    </doc>
+  </function>
+</namespace>
+</mrdocs>

--- a/test-files/golden-tests/config/sort-namespace-members-by/sort-namespace-members-by-name.yml
+++ b/test-files/golden-tests/config/sort-namespace-members-by/sort-namespace-members-by-name.yml
@@ -1,0 +1,1 @@
+sort-namespace-members-by: name

--- a/test-files/golden-tests/config/sort/unordered.adoc
+++ b/test-files/golden-tests/config/sort/unordered.adoc
@@ -342,6 +342,16 @@ Constructors
 
 Declared in `&lt;unordered&period;cpp&gt;`
 
+Default constructor
+
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+link:#Z-2constructor-05[Z]();
+----
+
+[.small]#link:#Z-2constructor-05[_» more&period;&period;&period;_]#
+
 Construct from `int`
 
 
@@ -352,15 +362,19 @@ link:#Z-2constructor-06[Z](int value);
 
 [.small]#link:#Z-2constructor-06[_» more&period;&period;&period;_]#
 
+[#Z-2constructor-05]
+== link:#Z[Z]::Z
+
 Default constructor
 
+=== Synopsis
+
+Declared in `&lt;unordered&period;cpp&gt;`
 
 [source,cpp,subs="verbatim,replacements,macros,-callouts"]
 ----
-link:#Z-2constructor-05[Z]();
+Z();
 ----
-
-[.small]#link:#Z-2constructor-05[_» more&period;&period;&period;_]#
 
 [#Z-2constructor-06]
 == link:#Z[Z]::Z
@@ -385,20 +399,6 @@ Z(int value);
 | *value*
 | The value to construct from
 |===
-
-[#Z-2constructor-05]
-== link:#Z[Z]::Z
-
-Default constructor
-
-=== Synopsis
-
-Declared in `&lt;unordered&period;cpp&gt;`
-
-[source,cpp,subs="verbatim,replacements,macros,-callouts"]
-----
-Z();
-----
 
 [#operator_not_eq]
 == operator!&equals;

--- a/test-files/golden-tests/config/sort/unordered.xml
+++ b/test-files/golden-tests/config/sort/unordered.xml
@@ -179,6 +179,14 @@
         </brief>
       </doc>
     </function>
+    <function class="constructor" name="Z" id="WltomC+2IcmzMN0COGL0OWWmbZk=">
+      <file short-path="unordered.cpp" source-path="unordered.cpp" line="32"/>
+      <doc>
+        <brief>
+          <text>Default constructor</text>
+        </brief>
+      </doc>
+    </function>
     <function class="constructor" name="Z" id="aQWtFVa4Xa+eceLXiLW74q44JRk=">
       <file short-path="unordered.cpp" source-path="unordered.cpp" line="31"/>
       <param name="value">
@@ -192,14 +200,6 @@
         <param name="value">
           <text>The value to construct from</text>
         </param>
-      </doc>
-    </function>
-    <function class="constructor" name="Z" id="WltomC+2IcmzMN0COGL0OWWmbZk=">
-      <file short-path="unordered.cpp" source-path="unordered.cpp" line="32"/>
-      <doc>
-        <brief>
-          <text>Default constructor</text>
-        </brief>
       </doc>
     </function>
   </struct>

--- a/test-files/golden-tests/config/sort/unordered.yml
+++ b/test-files/golden-tests/config/sort/unordered.yml
@@ -4,3 +4,4 @@ sort-members-dtors-1st: false
 sort-members-assignment-1st: false
 sort-members-conversion-last: false
 sort-members-relational-last: false
+sort-namespace-members-by: location

--- a/util/generate-config-info.py
+++ b/util/generate-config-info.py
@@ -65,7 +65,8 @@ def get_valid_enum_categories():
     valid_enum_cats = {
         'generator': ["adoc", "html", "xml"],
         'log-level': ["trace", "debug", "info", "warn", "error", "fatal"],
-        'base-member-inheritance': ["never", "reference", "copy-dependencies", "copy-all"]
+        'base-member-inheritance': ["never", "reference", "copy-dependencies", "copy-all"],
+        'sort-symbol-by': ["name", "location"]
     }
     return valid_enum_cats
 


### PR DESCRIPTION
- `sort-members` no longer affects namespaces
- `sort-members-by` determines the criteria for sorting record members
- namespace members are always sorted
- `sort-namespace-members-by` determines the criteria for sorting namespace members