### PR TITLE
fix: reproducible standard library for clang-cl

### DIFF
--- a/src/lib/MrDocsCompilationDatabase.cpp
+++ b/src/lib/MrDocsCompilationDatabase.cpp
@@ -445,8 +445,7 @@ adjustCommandLine(
         // implicit include paths and add the standard library
         // and system includes manually. That gives MrDocs
         // access to libc++ in a portable way.
-        new_cmdline.emplace_back("-nostdinc++");
-        new_cmdline.emplace_back("-nostdlib++");
+        new_cmdline.emplace_back(is_clang_cl ? "/X" : "-nostdinc++");
         for (auto const& inc : (*config)->stdlibIncludes)
         {
           new_cmdline.emplace_back(is_clang_cl ? std::format("-external:I{}", inc) : std::format("-isystem{}", inc));

--- a/src/lib/MrDocsCompilationDatabase.cpp
+++ b/src/lib/MrDocsCompilationDatabase.cpp
@@ -430,8 +430,8 @@ adjustCommandLine(
             it != implicitIncludeDirectories.end()) {
             for (auto const& inc : it->second)
             {
-              new_cmdline.emplace_back(std::format("-isystem{}", inc));
-            }          
+              new_cmdline.emplace_back(is_clang_cl ? std::format("-external:I{}", inc) : std::format("-isystem{}", inc));
+            }
         }
     }
 
@@ -449,7 +449,7 @@ adjustCommandLine(
         new_cmdline.emplace_back("-nostdlib++");
         for (auto const& inc : (*config)->stdlibIncludes)
         {
-          new_cmdline.emplace_back(std::format("-isystem{}", inc));
+          new_cmdline.emplace_back(is_clang_cl ? std::format("-external:I{}", inc) : std::format("-isystem{}", inc));
         }
     }
 
@@ -458,7 +458,7 @@ adjustCommandLine(
         new_cmdline.emplace_back("-nostdinc");
         for (auto const& inc : (*config)->libcIncludes)
         {
-          new_cmdline.emplace_back(std::format("-isystem{}", inc));
+          new_cmdline.emplace_back(is_clang_cl ? std::format("-external:I{}", inc) : std::format("-isystem{}", inc));
         }
     }
 
@@ -467,7 +467,7 @@ adjustCommandLine(
     // ------------------------------------------------------
     for (auto const& inc : (*config)->systemIncludes)
     {
-      new_cmdline.emplace_back(std::format("-isystem{}", inc));
+      new_cmdline.emplace_back(is_clang_cl ? std::format("-external:I{}", inc) : std::format("-isystem{}", inc));
     }
     for (auto const& inc : (*config)->includes)
     {

--- a/src/lib/SingleFileDB.hpp
+++ b/src/lib/SingleFileDB.hpp
@@ -30,17 +30,25 @@ class SingleFileDB
 public:
     explicit
     SingleFileDB(
-        llvm::StringRef pathName)
+        llvm::StringRef pathName, bool is_clang_cl = false)
     {
         auto fileName = files::getFileName(pathName);
         auto parentDir = files::getParentDir(pathName);
 
         std::vector<std::string> cmds;
-        cmds.emplace_back("clang");
+        if (is_clang_cl) {
+            cmds.emplace_back("clang-cl");
+            cmds.emplace_back("/std:c++latest");
+            cmds.emplace_back("/permissive-");
+            cmds.emplace_back("/WX");
+        }
+        else {
+            cmds.emplace_back("clang");
+            cmds.emplace_back("-std=c++23");
+            cmds.emplace_back("-pedantic-errors");
+            cmds.emplace_back("-Werror");
+        }
         cmds.emplace_back("-fsyntax-only");
-        cmds.emplace_back("-std=c++23");
-        cmds.emplace_back("-pedantic-errors");
-        cmds.emplace_back("-Werror");
         cmds.emplace_back(fileName);
         cc_.emplace_back(
             parentDir,

--- a/src/test/TestRunner.cpp
+++ b/src/test/TestRunner.cpp
@@ -114,9 +114,15 @@ handleFile(
 
     // Create an adjusted MrDocsDatabase
     auto parentDir = files::getParentDir(filePath);
+    bool const is_clang_cl =
+#if defined(WIN32)
+        true;
+#else
+        false;
+#endif
     std::unordered_map<std::string, std::vector<std::string>> defaultIncludePaths;
     MrDocsCompilationDatabase compilations(
-        llvm::StringRef(parentDir), SingleFileDB(filePath), config, defaultIncludePaths);
+        llvm::StringRef(parentDir), SingleFileDB(filePath, is_clang_cl), config, defaultIncludePaths);
 
     report::debug("Building Corpus", filePath);
     auto corpus = CorpusImpl::build(config, compilations);


### PR DESCRIPTION
fix #904
