### PR TITLE
refactor: cl arguments always map to regular arguments

### DIFF
--- a/src/lib/MrDocsCompilationDatabase.cpp
+++ b/src/lib/MrDocsCompilationDatabase.cpp
@@ -300,18 +300,6 @@ adjustCommandLine(
         cmdLineCStrs.data() + cmdLineCStrs.size());
 
     // ------------------------------------------------------
-    // Get driver mode
-    // ------------------------------------------------------
-    // The driver mode distinguishes between clang/gcc and msvc
-    // command line option formats. The value is deduced from
-    // the `-drive-mode` option or from `progName`.
-    // Common values are "gcc", "g++", "cpp", "cl" and "flang".
-    StringRef const driver_mode = driver::getDriverMode(progName, cmdLineCStrs);
-    // Identify if we should use "msvc/clang-cl" or "clang/gcc" format
-    // for options.
-    bool const is_clang_cl = driver::IsClangCL(driver_mode);
-
-    // ------------------------------------------------------
     // Supress all warnings
     // ------------------------------------------------------
     // Add flags to ignore all warnings. Any options that
@@ -490,6 +478,18 @@ adjustCommandLine(
     {
       new_cmdline.emplace_back(std::format("-I{}", inc));
     }
+
+    // ------------------------------------------------------
+    // Get driver mode
+    // ------------------------------------------------------
+    // The driver mode distinguishes between clang/gcc and msvc
+    // command line option formats. The value is deduced from
+    // the `-drive-mode` option or from `progName`.
+    // Common values are "gcc", "g++", "cpp", "cl" and "flang".
+    StringRef const driver_mode = driver::getDriverMode(progName, cmdLineCStrs);
+    // Identify if we should use "msvc/clang-cl" or "clang/gcc" format
+    // for options.
+    bool const is_clang_cl = driver::IsClangCL(driver_mode);
 
     // ------------------------------------------------------
     // Adjust each argument in the command line

--- a/src/lib/MrDocsCompilationDatabase.cpp
+++ b/src/lib/MrDocsCompilationDatabase.cpp
@@ -224,6 +224,7 @@ isValidMrDocsOption(
              driver::options::OPT__SLASH_EH,
              driver::options::OPT__SLASH_GR,
              driver::options::OPT__SLASH_GR_,
+             driver::options::OPT__SLASH_M_Group,
 
             // input file options
             //driver::options::OPT_INPUT,

--- a/src/lib/MrDocsCompilationDatabase.cpp
+++ b/src/lib/MrDocsCompilationDatabase.cpp
@@ -402,9 +402,10 @@ adjustCommandLine(
         isExplicitCCompileCommand || (!isExplicitCppCompileCommand && isImplicitCSourceFile);
 
     constexpr auto is_std_option = [](std::string_view const opt) {
-        return opt.starts_with("-std=") || opt.starts_with("--std=") || opt.starts_with("/std:") || opt.starts_with("-std:");
+        return opt.starts_with("-std=") || opt.starts_with("--std=") ||
+            opt.starts_with("/std:") || opt.starts_with("-std:");
     };
-    if (std::ranges::find_if(cmdline, is_std_option) == cmdline.end())
+    if (std::ranges::none_of(cmdline, is_std_option))
     {
         if (!isCCompileCommand)
         {
@@ -440,7 +441,7 @@ adjustCommandLine(
             for (auto const& inc : it->second)
             {
               new_cmdline.emplace_back(std::format("-isystem{}", inc));
-            }          
+            }
         }
     }
 

--- a/src/lib/MrDocsCompilationDatabase.cpp
+++ b/src/lib/MrDocsCompilationDatabase.cpp
@@ -510,8 +510,6 @@ adjustCommandLine(
     while (idx < cmdline.size())
     {
         // Parse one argument as a Clang option
-        // ParseOneArg updates Index to the next argument to be parsed.
-        unsigned const idx0 = idx;
         std::unique_ptr<llvm::opt::Arg> arg =
             opts_table.ParseOneArg(args, idx, visibility);
         if (!isValidMrDocsOption(workingDir, arg))

--- a/src/lib/MrDocsCompilationDatabase.cpp
+++ b/src/lib/MrDocsCompilationDatabase.cpp
@@ -222,6 +222,8 @@ isValidMrDocsOption(
              driver::options::OPT_flang_ignored_w_Group,
              driver::options::OPT__SLASH_O,
              driver::options::OPT__SLASH_EH,
+             driver::options::OPT__SLASH_GR,
+             driver::options::OPT__SLASH_GR_,
 
             // input file options
             //driver::options::OPT_INPUT,

--- a/src/lib/MrDocsCompilationDatabase.cpp
+++ b/src/lib/MrDocsCompilationDatabase.cpp
@@ -525,7 +525,7 @@ adjustCommandLine(
             MRDOCS_ASSERT(arg->getNumValues() == 1);
 
             std::string_view v = arg->getValue();
-            if (v == "c++latest" || v == "c++preview")
+            if (v == "c++latest" || v == "c++23preview")
             {
                 new_cmdline.emplace_back("-std=c++23");
             }

--- a/src/lib/MrDocsCompilationDatabase.cpp
+++ b/src/lib/MrDocsCompilationDatabase.cpp
@@ -219,10 +219,10 @@ isValidMrDocsOption(
              driver::options::OPT_clang_ignored_gcc_optimization_f_Group,
              driver::options::OPT_clang_ignored_legacy_options_Group,
              driver::options::OPT_clang_ignored_m_Group,
-             driver::options::OPT_flang_ignored_w_Group
-#if 0
+             driver::options::OPT_flang_ignored_w_Group,
+
             // input file options
-            driver::options::OPT_INPUT,
+            //driver::options::OPT_INPUT,
 
             // output file options
             driver::options::OPT_o,
@@ -237,11 +237,10 @@ isValidMrDocsOption(
             driver::options::OPT__SLASH_Fr,
             driver::options::OPT__SLASH_Fm,
             driver::options::OPT__SLASH_Fx,
-#endif
-            // driver::options::OPT__SLASH_TP
-            // driver::options::OPT__SLASH_Tp
-            // driver::options::OPT__SLASH_TC
-            // driver::options::OPT__SLASH_Tc
+            driver::options::OPT__SLASH_TP,
+            driver::options::OPT__SLASH_Tp,
+            driver::options::OPT__SLASH_TC,
+            driver::options::OPT__SLASH_Tc
     ))
     {
         return false;

--- a/src/lib/MrDocsCompilationDatabase.cpp
+++ b/src/lib/MrDocsCompilationDatabase.cpp
@@ -225,6 +225,8 @@ isValidMrDocsOption(
              driver::options::OPT__SLASH_GR,
              driver::options::OPT__SLASH_GR_,
              driver::options::OPT__SLASH_M_Group,
+             driver::options::OPT__SLASH_MP,
+             driver::options::OPT__SLASH_Zc,
 
             // input file options
             //driver::options::OPT_INPUT,

--- a/src/lib/MrDocsCompilationDatabase.cpp
+++ b/src/lib/MrDocsCompilationDatabase.cpp
@@ -288,7 +288,7 @@ adjustCommandLine(
     // Copy the compiler path
     // ------------------------------------------------------
     std::string const& progName = cmdline.front();
-    std::vector new_cmdline = {progName};
+    std::vector new_cmdline = {std::string{"clang"}};
 
     // ------------------------------------------------------
     // Convert to InputArgList
@@ -317,7 +317,7 @@ adjustCommandLine(
     // ------------------------------------------------------
     // Add flags to ignore all warnings. Any options that
     // affect warnings will be discarded later.
-    new_cmdline.emplace_back(is_clang_cl ? "/w" : "-w");
+    new_cmdline.emplace_back("-w");
     new_cmdline.emplace_back("-fsyntax-only");
 
     // ------------------------------------------------------

--- a/src/lib/MrDocsCompilationDatabase.cpp
+++ b/src/lib/MrDocsCompilationDatabase.cpp
@@ -220,6 +220,8 @@ isValidMrDocsOption(
              driver::options::OPT_clang_ignored_legacy_options_Group,
              driver::options::OPT_clang_ignored_m_Group,
              driver::options::OPT_flang_ignored_w_Group,
+             driver::options::OPT__SLASH_O,
+             driver::options::OPT__SLASH_EH,
 
             // input file options
             //driver::options::OPT_INPUT,

--- a/src/lib/MrDocsCompilationDatabase.cpp
+++ b/src/lib/MrDocsCompilationDatabase.cpp
@@ -514,10 +514,14 @@ adjustCommandLine(
         {
             continue;
         }
-        new_cmdline.insert(
-            new_cmdline.end(),
-            cmdline.begin() + idx0,
-            cmdline.begin() + idx);
+
+        // Append the translated arguments to the new command line
+        llvm::opt::ArgStringList output;
+        arg->render(args, output);
+
+        for (auto const& v : output) {
+            new_cmdline.push_back(v);
+        }
     }
 
     return new_cmdline;

--- a/src/lib/MrDocsCompilationDatabase.cpp
+++ b/src/lib/MrDocsCompilationDatabase.cpp
@@ -403,8 +403,8 @@ adjustCommandLine(
         isExplicitCCompileCommand || (!isExplicitCppCompileCommand && isImplicitCSourceFile);
 
     constexpr auto is_std_option = [](std::string_view const opt) {
-        return opt.starts_with("-std=") || opt.starts_with("--std=") ||
-            opt.starts_with("/std:") || opt.starts_with("-std:");
+        return opt.starts_with("-std=") || opt.starts_with("--std=") || // clang options
+            opt.starts_with("/std:") || opt.starts_with("-std:"); // clang-cl options
     };
     if (std::ranges::none_of(cmdline, is_std_option))
     {

--- a/src/test/lib/MrDocsCompilationDatabase.cpp
+++ b/src/test/lib/MrDocsCompilationDatabase.cpp
@@ -80,12 +80,65 @@ struct MrDocsCompilationDatabase_test
         return compilations.getCompileCommands(cc.Filename).front().CommandLine;
     }
 
+    void testClangCLStdFlag()
+    {
+        // /std:c++14 -> -std=c++14
+        {
+            auto adjusted = adjustCompileCommand({ "clang-cl", "/std:c++14"});
+            BOOST_TEST_GE(adjusted.size(), 2);
+            BOOST_TEST(contains(adjusted, "-std=c++14"));
+        }
+
+        // /std:c++17 -> -std=c++17
+        {
+            auto adjusted = adjustCompileCommand({ "clang-cl", "/std:c++17"});
+            BOOST_TEST_GE(adjusted.size(), 2);
+            BOOST_TEST(contains(adjusted, "-std=c++17"));
+        }
+
+        // /std:c++20 -> -std=c++20
+        {
+            auto adjusted = adjustCompileCommand({ "clang-cl", "/std:c++20"});
+            BOOST_TEST_GE(adjusted.size(), 2);
+            BOOST_TEST(contains(adjusted, "-std=c++20"));
+        }
+
+        // /std:c++23preview -> -std=c++23
+        {
+            auto adjusted = adjustCompileCommand({ "clang-cl", "/std:c++23preview"});
+            BOOST_TEST_GE(adjusted.size(), 2);
+            BOOST_TEST(contains(adjusted, "-std=c++23"));
+        }
+
+        // /std:c++latest -> -std=c++23
+        {
+            auto adjusted = adjustCompileCommand({ "clang-cl", "/std:c++latest"});
+            BOOST_TEST_GE(adjusted.size(), 2);
+            BOOST_TEST(contains(adjusted, "-std=c++23"));
+        }
+
+        // /std:c11 -> -std=c11
+        {
+            auto adjusted = adjustCompileCommand({ "clang-cl", "/std:c11"});
+            BOOST_TEST_GE(adjusted.size(), 2);
+            BOOST_TEST(contains(adjusted, "-std=c11"));
+        }
+        
+        // /std:c17 -> -std=c17
+        {
+            auto adjusted = adjustCompileCommand({ "clang-cl", "/std:c17"});
+            BOOST_TEST_GE(adjusted.size(), 2);
+            BOOST_TEST(contains(adjusted, "-std=c17"));
+        }
+    }
+
     void testClangCL()
     {
-         auto adjusted = adjustCompileCommand({ "clang-cl", "/std:c++latest"});
-         BOOST_TEST_GE(adjusted.size(), 2);
-         BOOST_TEST_EQ(adjusted[0], "clang");
-         BOOST_TEST(contains(adjusted, "-std=c++23"));
+        auto adjusted = adjustCompileCommand({ "clang-cl"});
+        BOOST_TEST_GE(adjusted.size(), 1);
+        BOOST_TEST_EQ(adjusted[0], "clang");
+
+        testClangCLStdFlag();
     }
 
     void run()

--- a/src/test/lib/MrDocsCompilationDatabase.cpp
+++ b/src/test/lib/MrDocsCompilationDatabase.cpp
@@ -1,0 +1,102 @@
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (c) 2023 Vinnie Falco (vinnie.falco@gmail.com)
+//
+// Official repository: https://github.com/cppalliance/mrdocs
+//
+
+#include "lib/ConfigImpl.hpp"
+#include "lib/MrDocsCompilationDatabase.hpp"
+#include "lib/SingleFileDB.hpp"
+#include <mrdocs/Support/Algorithm.hpp>
+#include <mrdocs/Support/Path.hpp>
+#include <mrdocs/Support/ThreadPool.hpp>
+#include <test_suite/test_suite.hpp>
+
+namespace clang {
+namespace mrdocs {
+
+/** Compilation database for a single .cpp file.
+*/
+class SingleFileTestDB
+    : public tooling::CompilationDatabase
+{
+    tooling::CompileCommand cc_;
+
+public:
+    explicit
+    SingleFileTestDB(
+        tooling::CompileCommand cc)
+        : cc_(std::move(cc))
+    {}
+
+    std::vector<tooling::CompileCommand>
+    getCompileCommands(
+        llvm::StringRef FilePath) const override
+    {
+        if (FilePath != cc_.Filename)
+            return {};
+        return { cc_ };
+    }
+
+    std::vector<std::string>
+    getAllFiles() const override
+    {
+        return { cc_.Filename };
+    }
+
+    std::vector<tooling::CompileCommand>
+    getAllCompileCommands() const override
+    {
+        return { cc_ };
+    }
+};
+
+struct MrDocsCompilationDatabase_test
+{
+    Config::Settings fileSettings_;
+    ThreadPool threadPool_;
+    ReferenceDirectories dirs_;
+
+    std::shared_ptr<ConfigImpl const> config_ =
+        ConfigImpl::load(fileSettings_, dirs_, threadPool_).value();
+
+    auto adjustCompileCommand(std::vector<std::string> CommandLine) const
+    {
+        tooling::CompileCommand cc;
+        cc.Directory = ".";
+        cc.Filename = "test.cpp"; // file does not exist
+        cc.CommandLine = std::move(CommandLine);
+        cc.CommandLine.push_back(cc.Filename);
+        cc.Heuristic = "unit test";
+
+        // Create an adjusted MrDocsDatabase
+        std::unordered_map<std::string, std::vector<std::string>> defaultIncludePaths;
+        MrDocsCompilationDatabase compilations(
+            llvm::StringRef(cc.Directory), SingleFileTestDB(cc), config_, defaultIncludePaths);
+        return compilations.getCompileCommands(cc.Filename).front().CommandLine;
+    }
+
+    void testClangCL()
+    {
+         auto adjusted = adjustCompileCommand({ "clang-cl", "/std:c++latest"});
+         BOOST_TEST_GE(adjusted.size(), 2);
+         BOOST_TEST_EQ(adjusted[0], "clang");
+         BOOST_TEST(contains(adjusted, "-std=c++23"));
+    }
+
+    void run()
+    {
+        testClangCL();
+    }
+};
+
+TEST_SUITE(
+    MrDocsCompilationDatabase_test,
+    "clang.mrdocs.MrDocsCompilationDatabase");
+
+} // mrdocs
+} // clang

--- a/src/test/lib/MrDocsCompilationDatabase.cpp
+++ b/src/test/lib/MrDocsCompilationDatabase.cpp
@@ -18,6 +18,7 @@
 namespace clang {
 namespace mrdocs {
 
+namespace {
 /** Compilation database for a single .cpp file.
 */
 class SingleFileTestDB
@@ -53,6 +54,7 @@ public:
         return { cc_ };
     }
 };
+}
 
 struct MrDocsCompilationDatabase_test
 {


### PR DESCRIPTION
as discussed in #997 