### PR TITLE
don't mark unnamed classes as implementation defined

### DIFF
--- a/src/lib/AST/ASTVisitor.cpp
+++ b/src/lib/AST/ASTVisitor.cpp
@@ -644,15 +644,6 @@ populate(
     RecordInfo& I,
     CXXRecordDecl const* D)
 {
-    // Unnamed structs and classes are implementation-defined
-    // or dependencies at best. There are never pages for them.
-    if (D->getIdentifier() == nullptr)
-    {
-        I.Extraction = mostSpecific(
-            ExtractionMode::ImplementationDefined,
-            I.Extraction);
-    }
-
     if (D->getTypedefNameForAnonDecl())
     {
         I.IsTypeDef = true;

--- a/test-files/golden-tests/symbols/record/unnamed.adoc
+++ b/test-files/golden-tests/symbols/record/unnamed.adoc
@@ -4,13 +4,102 @@
 [#index]
 == Global namespace
 
+=== Types
+
+[cols=2]
+|===
+| Name
+| Description
+| link:#_01record-01[`Unnamed struct`] 
+| 
+| link:#_01record-0f[`Unnamed struct`] 
+| A test unnamed class&period;
+|===
+
 === Variables
+
+[cols=2]
+|===
+| Name
+| Description
+| link:#F[`F`] 
+| 
+| link:#x[`x`] 
+| A test variable named &apos;x&apos;
+| link:#y[`y`] 
+| A test variable named &apos;y&apos;
+|===
+
+[#_01record-01]
+== Unnamed struct
+
+=== Synopsis
+
+Declared in `&lt;unnamed&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+struct Unnamed struct;
+----
+
+=== Member Functions
 
 [cols=1]
 |===
 | Name
-| link:#F[`F`] 
+| link:#_01record-01-operator_call[`operator()`] 
 |===
+
+[#_01record-01-operator_call]
+== operator()
+
+=== Synopsis
+
+Declared in `&lt;unnamed&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+void
+operator()() const;
+----
+
+[#_01record-0f]
+== Unnamed struct
+
+A test unnamed class&period;
+
+=== Synopsis
+
+Declared in `&lt;unnamed&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+struct Unnamed struct;
+----
+
+=== Data Members
+
+[cols=2]
+|===
+| Name
+| Description
+| link:#_01record-0f-a[`a`] 
+| A test field&period;
+|===
+
+[#_01record-0f-a]
+== a
+
+A test field&period;
+
+=== Synopsis
+
+Declared in `&lt;unnamed&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+int a;
+----
 
 [#F]
 == F
@@ -21,7 +110,37 @@ Declared in `&lt;unnamed&period;cpp&gt;`
 
 [source,cpp,subs="verbatim,replacements,macros,-callouts"]
 ----
-constexpr &sol;&ast; implementation-defined &ast;&sol; F = &lcub;&rcub;;
+constexpr link:#_01record-01[] F = &lcub;&rcub;;
+----
+
+[#x]
+== x
+
+A test variable named &apos;x&apos;
+
+=== Synopsis
+
+Declared in `&lt;unnamed&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+extern
+link:#_01record-0f[] x;
+----
+
+[#y]
+== y
+
+A test variable named &apos;y&apos;
+
+=== Synopsis
+
+Declared in `&lt;unnamed&period;cpp&gt;`
+
+[source,cpp,subs="verbatim,replacements,macros,-callouts"]
+----
+extern
+link:#_01record-0f[] y;
 ----
 
 

--- a/test-files/golden-tests/symbols/record/unnamed.cpp
+++ b/test-files/golden-tests/symbols/record/unnamed.cpp
@@ -2,3 +2,13 @@ constexpr struct
 {
     void operator()() const;
 } const F{};
+
+/// A test unnamed class.
+extern struct {
+  /// A test field.
+  int a;
+}
+  /// A test variable named 'x'
+  x,
+  /// A test variable named 'y'
+  y;

--- a/test-files/golden-tests/symbols/record/unnamed.html
+++ b/test-files/golden-tests/symbols/record/unnamed.html
@@ -9,7 +9,53 @@
 <div>
 <h2 id="index"><a href="#index"></a></h2>
 </div>
+<h2>Types</h2>
+<table style="table-layout: fixed; width: 100%;">
+<thead>
+<tr>
+<th>Name</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a href="#_01record-01"><code>Unnamed struct</code></a> </td><td><span></span></td></tr><tr>
+<td><a href="#_01record-0f"><code>Unnamed struct</code></a> </td><td><span>A test unnamed class.</span></td></tr>
+</tbody>
+</table>
+
 <h2>Variables</h2>
+<table style="table-layout: fixed; width: 100%;">
+<thead>
+<tr>
+<th>Name</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a href="#F"><code>F</code></a> </td><td><span></span></td></tr><tr>
+<td><a href="#x"><code>x</code></a> </td><td><span>A test variable named &#x27;x&#x27;</span></td></tr><tr>
+<td><a href="#y"><code>y</code></a> </td><td><span>A test variable named &#x27;y&#x27;</span></td></tr>
+</tbody>
+</table>
+
+</div>
+<div>
+<div>
+<h2 id="_01record-01"><a href="#_01record-01"></a></h2>
+</div>
+<div>
+<h3>Synopsis</h3>
+<div>
+Declared in <code>&lt;unnamed.cpp&gt;</code></div>
+<pre>
+<code class="source-code cpp">struct Unnamed struct;
+
+</code>
+</pre>
+</div>
+<h2>Member Functions</h2>
 <table style="table-layout: fixed; width: 100%;">
 <thead>
 <tr>
@@ -18,10 +64,82 @@
 </thead>
 <tbody>
 <tr>
-<td><a href="#F"><code>F</code></a> </td></tr>
+<td><a href="#_01record-01-operator_call"><code>operator()</code></a> </td></tr>
 </tbody>
 </table>
 
+
+
+</div>
+<div>
+<div>
+<h2 id="_01record-01-operator_call"><a href="#_01record-01-operator_call">::operator()</a></h2>
+</div>
+<div>
+<h3>Synopsis</h3>
+<div>
+Declared in <code>&lt;unnamed.cpp&gt;</code></div>
+<pre>
+<code class="source-code cpp">void
+operator()() const;
+
+</code>
+</pre>
+</div>
+</div>
+<div>
+<div>
+<h2 id="_01record-0f"><a href="#_01record-0f"></a></h2>
+<div>
+<span>A test unnamed class.</span>
+
+</div>
+</div>
+<div>
+<h3>Synopsis</h3>
+<div>
+Declared in <code>&lt;unnamed.cpp&gt;</code></div>
+<pre>
+<code class="source-code cpp">struct Unnamed struct;
+
+</code>
+</pre>
+</div>
+<h2>Data Members</h2>
+<table style="table-layout: fixed; width: 100%;">
+<thead>
+<tr>
+<th>Name</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a href="#_01record-0f-a"><code>a</code></a> </td><td><span>A test field.</span></td></tr>
+</tbody>
+</table>
+
+
+
+</div>
+<div>
+<div>
+<h2 id="_01record-0f-a"><a href="#_01record-0f-a">::a</a></h2>
+<div>
+<span>A test field.</span>
+
+</div>
+</div>
+<div>
+<h3>Synopsis</h3>
+<div>
+Declared in <code>&lt;unnamed.cpp&gt;</code></div>
+<pre>
+<code class="source-code cpp">int a;
+
+</code>
+</pre>
+</div>
 </div>
 <div>
 <div>
@@ -32,7 +150,47 @@
 <div>
 Declared in <code>&lt;unnamed.cpp&gt;</code></div>
 <pre>
-<code class="source-code cpp">constexpr /* implementation-defined */ F = {};
+<code class="source-code cpp">constexpr <a href="#_01record-01"></a> F = {};
+
+</code>
+</pre>
+</div>
+</div>
+<div>
+<div>
+<h2 id="x"><a href="#x">x</a></h2>
+<div>
+<span>A test variable named &#x27;x&#x27;</span>
+
+</div>
+</div>
+<div>
+<h3>Synopsis</h3>
+<div>
+Declared in <code>&lt;unnamed.cpp&gt;</code></div>
+<pre>
+<code class="source-code cpp">extern
+<a href="#_01record-0f"></a> x;
+
+</code>
+</pre>
+</div>
+</div>
+<div>
+<div>
+<h2 id="y"><a href="#y">y</a></h2>
+<div>
+<span>A test variable named &#x27;y&#x27;</span>
+
+</div>
+</div>
+<div>
+<h3>Synopsis</h3>
+<div>
+Declared in <code>&lt;unnamed.cpp&gt;</code></div>
+<pre>
+<code class="source-code cpp">extern
+<a href="#_01record-0f"></a> y;
 
 </code>
 </pre>

--- a/test-files/golden-tests/symbols/record/unnamed.xml
+++ b/test-files/golden-tests/symbols/record/unnamed.xml
@@ -4,11 +4,53 @@
 <namespace id="//////////////////////////8=">
   <struct name="" id="F1Jq7+g4G9C/ONGL1uiGY4NNso4=">
     <file short-path="unnamed.cpp" source-path="unnamed.cpp" line="1" class="def"/>
+    <function name="operator()" id="yiR+Q9T0kIzuR5+cO8MjyUGxhD4=">
+      <file short-path="unnamed.cpp" source-path="unnamed.cpp" line="3"/>
+      <attr id="operator" name="call" value="42"/>
+      <attr id="is-const"/>
+    </function>
+  </struct>
+  <struct name="" id="8AwuUPjsLEReggyF5UohZMvrh8k=">
+    <file short-path="unnamed.cpp" source-path="unnamed.cpp" line="7" class="def"/>
+    <doc>
+      <brief>
+        <text>A test unnamed class.</text>
+      </brief>
+    </doc>
+    <variable name="a" id="4Sy+GbRmqI4igByqQo0hAnRUahY=">
+      <file short-path="unnamed.cpp" source-path="unnamed.cpp" line="9"/>
+      <type name="int"/>
+      <doc>
+        <brief>
+          <text>A test field.</text>
+        </brief>
+      </doc>
+    </variable>
   </struct>
   <variable name="F" id="BGjARRRB5KxbD8yjAiXJFTuHZdc=" default="{}">
     <file short-path="unnamed.cpp" source-path="unnamed.cpp" line="1" class="def"/>
     <attr id="is-constexpr"/>
     <type id="F1Jq7+g4G9C/ONGL1uiGY4NNso4=" name=""/>
+  </variable>
+  <variable name="x" id="O3vj5ch+AFTAIMnsaVF06Ms3nc0=">
+    <file short-path="unnamed.cpp" source-path="unnamed.cpp" line="7"/>
+    <attr id="storage-class" name="extern" value="1"/>
+    <type id="8AwuUPjsLEReggyF5UohZMvrh8k=" name=""/>
+    <doc>
+      <brief>
+        <text>A test variable named &apos;x&apos;</text>
+      </brief>
+    </doc>
+  </variable>
+  <variable name="y" id="SEYEjN6YLJp3VM0ue8amNlWQiTU=">
+    <file short-path="unnamed.cpp" source-path="unnamed.cpp" line="7"/>
+    <attr id="storage-class" name="extern" value="1"/>
+    <type id="8AwuUPjsLEReggyF5UohZMvrh8k=" name=""/>
+    <doc>
+      <brief>
+        <text>A test variable named &apos;y&apos;</text>
+      </brief>
+    </doc>
   </variable>
 </namespace>
 </mrdocs>


### PR DESCRIPTION
These classes can appear as user written code and needs to be documented, as show in the new test case.

In general, for implementation defined declarations, we can detect them as the clang AST exposes them as 'implicit', but this is possible for any declaration, and can be handled more generally.

This is related to https://github.com/cppalliance/mrdocs/issues/1054: We have no way to mark these classes as implementation defined with this change.

This is also related to https://github.com/cppalliance/mrdocs/issues/1055, as the HTML generator has some issues printing unnamed entities.

Fixes #1035