### PR TITLE
feat(docs): light-mode support for the brand theme

### DIFF
--- a/docs/shared/logo.css
+++ b/docs/shared/logo.css
@@ -23,7 +23,7 @@
 
 .nav .logo-text, .navbar-brand .navbar-item:first-child .logo-text {
     font-weight: 700;
-    color: #fff;
+    color: var(--logo-text-color);
     white-space: nowrap;
     font-size: 1rem;
 }

--- a/docs/ui/src/css/adoc-preview.css
+++ b/docs/ui/src/css/adoc-preview.css
@@ -22,9 +22,9 @@
   position: relative;
   margin: 1.25rem 0 1.75rem;
   padding: 4rem 1.5rem 1.5rem;
-  border: 1px solid rgba(255, 255, 255, 0.15);
+  border: 1px solid var(--border);
   border-radius: 8px;
-  background-color: rgba(255, 255, 255, 0.07);
+  background-color: var(--surface-2);
   backdrop-filter: blur(10px);
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.15);
 }
@@ -45,8 +45,8 @@
   right: 0;
   padding: 0.55rem 1.5rem;
   font-size: 0.7rem;
-  background: rgba(255, 255, 255, 0.05);
-  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  background: var(--surface-2);
+  border-bottom: 1px solid var(--border);
   border-top-left-radius: 8px;
   border-top-right-radius: 8px;
 }
@@ -59,18 +59,18 @@
 .doc .adoc-preview-label .primary {
   font-weight: 600;
   letter-spacing: 0.08em;
-  color: rgba(255, 255, 255, 0.7);
+  color: var(--text-muted);
 }
 
 .doc .adoc-preview-label .separator {
   margin: 0 0.55rem;
-  color: rgba(255, 255, 255, 0.25);
+  color: var(--text-muted);
 }
 
 .doc .adoc-preview-label .subtitle {
   font-weight: 500;
   letter-spacing: 0.02em;
-  color: rgba(255, 255, 255, 0.45);
+  color: var(--text-muted);
 }
 
 /*
@@ -106,12 +106,12 @@
 .doc .adoc-preview h4,
 .doc .adoc-preview h5 {
   font-size: 1.35rem;
-  color: rgba(255, 255, 255, 0.95);
+  color: var(--heading-font-color);
 }
 
 .doc .adoc-preview h6 {
   font-size: 0.8rem;
-  color: rgba(255, 255, 255, 0.55);
+  color: var(--text-muted);
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.06em;
@@ -145,12 +145,12 @@
  */
 
 .doc .adoc-preview table {
-  border-color: rgba(255, 255, 255, 0.15);
+  border-color: var(--border);
 }
 
 .doc .adoc-preview table th,
 .doc .adoc-preview table td {
-  border-color: rgba(255, 255, 255, 0.1);
+  border-color: var(--border);
 }
 
 /*
@@ -164,11 +164,11 @@
 .doc .adoc-preview .caption {
   margin: 1.5rem -1.5rem -1.5rem;
   padding: 0.75rem 1.5rem;
-  background: rgba(255, 255, 255, 0.05);
-  border-top: 1px solid rgba(255, 255, 255, 0.1);
+  background: var(--surface-2);
+  border-top: 1px solid var(--border);
   border-bottom-left-radius: 8px;
   border-bottom-right-radius: 8px;
-  color: rgba(255, 255, 255, 0.65);
+  color: var(--text-muted);
   font-size: 0.85rem;
   font-style: italic;
 }

--- a/docs/ui/src/css/custom.css
+++ b/docs/ui/src/css/custom.css
@@ -91,7 +91,7 @@
   letter-spacing: 0.6px;
   font-size: 1.45rem;
   line-height: 1;
-  color: var(--heading-color);
+  color: var(--heading-font-color);
 }
 
 /* Theme toggle button in the navbar. */
@@ -175,4 +175,37 @@
   .doc .dotted-right {
     display: none;
   }
+}
+
+/* -------------------------------------------------------------------------
+   Light/dark chrome fixes.
+   Keep the top overscroll area (which shows through in Safari above the fixed
+   navbar) the same colour as the navbar instead of the page background, so
+   there is no mismatched strip. Give the brand logo art a theme-aware fill so
+   the white line-work stays visible on the light chrome.
+   ------------------------------------------------------------------------- */
+html {
+  background-color: var(--navbar-background);
+}
+
+body {
+  background-color: var(--body-background);
+}
+
+.navbar {
+  border-bottom: 1px solid var(--border);
+}
+
+/* Monochrome white status icons (comparison tables, demo gallery) ship as
+   white <img> SVGs, so only a filter can recolour them; invert to dark on the
+   light theme so they don't vanish on the cream page. */
+.doc img[src*="/icons/"] {
+  filter: var(--doc-icon-filter);
+}
+
+.navbar-brand svg {
+  /* Only the head silhouette follows this colour; the line-work is black in
+     the SVG. Transparent on light gives a black line drawing on the cream
+     chrome, white on dark fills the head under the black features. */
+  color: var(--logo-fill);
 }

--- a/docs/ui/src/css/doc.css
+++ b/docs/ui/src/css/doc.css
@@ -855,7 +855,7 @@ html {
 .doc .listingblock pre:not(.highlight),
 .doc .literalblock pre {
   background: var(--pre-background);
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  border: 1px solid var(--pre-border-color);
   border-radius: 6px;
   box-shadow: 0 1px 0 rgba(0, 0, 0, 0.4);
   display: block;
@@ -876,14 +876,14 @@ html {
  */
 .doc .listingblock > .title {
   background: var(--pre-background);
-  color: rgba(255, 255, 255, 0.55);
+  color: var(--hl-comment);
   font-family: var(--body-font-family);
   font-size: calc(13 / var(--rem-base) * 1rem);
   font-style: normal;
   font-weight: 500;
   letter-spacing: 0.02em;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  border: 1px solid var(--pre-border-color);
+  border-bottom: 1px solid var(--pre-border-color);
   border-radius: 6px 6px 0 0;
   padding: 0.55rem 1.25rem;
   margin-bottom: 0;

--- a/docs/ui/src/css/header.css
+++ b/docs/ui/src/css/header.css
@@ -9,7 +9,7 @@ body {
 }
 
 .navbar {
-  background-color: rgba(0, 0, 0, 0.2);
+  background-color: var(--navbar-background);
   backdrop-filter: blur(10px);
   color: var(--navbar-font-color);
   font-size: calc(16 / var(--rem-base) * 1rem);
@@ -228,7 +228,7 @@ body {
 
   .navbar-menu {
     box-shadow: 0 8px 16px rgba(10, 10, 10, 0.1);
-    background-color: rgb(47 47 94);
+    background-color: var(--navbar-menu-background);
     max-height: var(--body-min-height);
     overflow-y: auto;
     overscroll-behavior: none;

--- a/docs/ui/src/css/highlight.css
+++ b/docs/ui/src/css/highlight.css
@@ -31,7 +31,7 @@ code.hljs {
 }
 
 .hljs {
-  color: #adbac7;
+  color: var(--hl-fg);
   background: var(--pre-background);
 }
 
@@ -41,20 +41,20 @@ code.hljs {
  * to the rendered documentation. */
 .hljs-comment,
 .hljs-quote {
-  color: #768390;
+  color: var(--hl-comment);
   font-style: italic;
 }
 
 /* Keywords, storage, storage modifiers — red. */
 .hljs-keyword,
 .hljs-formula {
-  color: #f47067;
+  color: var(--hl-keyword);
 }
 
 /* Strings, regexes — pale blue. */
 .hljs-string,
 .hljs-regexp {
-  color: #96d0ff;
+  color: var(--hl-string);
 }
 
 /* Numbers, language constants, support symbols, attribute keys,
@@ -72,7 +72,7 @@ code.hljs {
 .hljs-selector-attr,
 .hljs-selector-pseudo,
 .hljs-meta {
-  color: #6cb6ff;
+  color: var(--hl-const);
 }
 
 /* Class/type/entity names, variables — orange. `hljs-params` is
@@ -89,14 +89,14 @@ code.hljs {
 .hljs-title.class_,
 .hljs-name,
 .hljs-variable {
-  color: #f69d50;
+  color: var(--hl-entity);
 }
 
 /* Function names — purple. */
 .hljs-title,
 .hljs-function .hljs-title,
 .hljs-title.function_ {
-  color: #dcbdfb;
+  color: var(--hl-title);
 }
 
 /* Tags, doctags, markup quotes — green. */
@@ -104,7 +104,7 @@ code.hljs {
 .hljs-doctag,
 .hljs-selector-tag,
 .hljs-section {
-  color: #8ddb8c;
+  color: var(--hl-tag);
 }
 
 /*
@@ -119,19 +119,19 @@ code.hljs {
  *     against the darker prose without introducing a third hue.
  */
 .hljs-doc-comment {
-  color: rgb(94, 135, 79);
+  color: var(--hl-doc);
   font-style: italic;
 }
 
 .hljs-doc-comment .hljs-doctag {
-  color: rgb(164, 181, 67);
+  color: var(--hl-doc-strong);
   font-style: normal;
   font-weight: 700;
 }
 
 .hljs-doc-comment .hljs-name,
 .hljs-doc-comment .hljs-string {
-  color: rgb(164, 181, 67);
+  color: var(--hl-doc-strong);
   font-style: italic;
 }
 

--- a/docs/ui/src/css/nav.css
+++ b/docs/ui/src/css/nav.css
@@ -5,7 +5,7 @@
 }
 
 .nav-container {
-  background-color: rgba(47, 44, 94, 0.75);
+  background-color: var(--nav-secondary-background);
   backdrop-filter: blur(10px);
   position: fixed;
   top: var(--navbar-height);
@@ -19,7 +19,8 @@
 @media screen and (min-width: 769px) {
   .nav-container {
     width: var(--nav-width);
-    background-color: transparent;
+    background-color: var(--nav-panel-background);
+    border-right: 1px solid var(--nav-border-color);
   }
 }
 
@@ -38,7 +39,7 @@
 }
 
 .nav {
-  background: rgba(255, 255, 255, 0.1);
+  background: var(--nav-panel-overlay);
   position: relative;
   height: var(--nav-height);
 }
@@ -186,7 +187,7 @@
 }
 
 .nav-panel-explore {
-  background: rgba(47, 44, 94, 0.75);
+  background: var(--nav-secondary-background);
   backdrop-filter: blur(10px);
   display: flex;
   flex-direction: column;
@@ -199,7 +200,7 @@
 
 @media screen and (min-width: 769px) {
   .nav-panel-explore {
-    background: rgba(255, 255, 255, 0.3);
+    background: var(--nav-explore-overlay);
   }
 }
 
@@ -209,7 +210,7 @@
 }
 
 .nav-panel-explore .context {
-  background: rgba(47, 44, 94, 0.75);
+  background: var(--nav-secondary-background);
   font-size: calc(15 / var(--rem-base) * 1rem);
   flex-shrink: 0;
   color: var(--color-white);
@@ -234,6 +235,9 @@
 .nav-panel-explore .context .version::after {
   content: "";
   background: url(../img/chevron.svg) no-repeat center right / auto 100%;
+  /* chevron.svg is fixed white; invert it to dark on the light theme so it
+     stays visible on the light nav panel. */
+  filter: var(--doc-icon-filter);
   width: 1.25em;
   height: 0.75em;
 }
@@ -242,7 +246,7 @@
   line-height: var(--nav-line-height);
   flex-grow: 1;
   box-shadow: 0 2px 8px 0 rgba(30, 50, 70, 0.3);
-  background-color: rgb(29 28 64);
+  background-color: var(--nav-secondary-background);
   padding: 0.75rem 0.75rem 0 0.75rem;
   margin: 0;
   overflow-y: scroll;

--- a/docs/ui/src/css/page-versions.css
+++ b/docs/ui/src/css/page-versions.css
@@ -12,15 +12,29 @@
 
 .page-versions .version-menu-toggle {
   color: var(--color-white);
-  background: url(../img/chevron.svg) no-repeat;
-  background-position: right 0.5rem top 50%;
-  background-size: auto 0.75em;
+  background: none;
   border: none;
   outline: none;
   line-height: inherit;
   padding: 0.5rem 1.5rem 0.5rem 0.5rem;
   position: relative;
   z-index: var(--z-index-page-version-menu);
+}
+
+/* Chevron on its own pseudo-element rather than as a background on the button:
+   the button also holds the version text, so filtering the button would
+   recolour the text too. The white chevron.svg is inverted to dark on the
+   light theme via the icon filter, leaving the text untouched. */
+.page-versions .version-menu-toggle::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  right: 0.5rem;
+  width: 0.75em;
+  height: 0.75em;
+  transform: translateY(-50%);
+  background: url(../img/chevron.svg) no-repeat center / contain;
+  filter: var(--doc-icon-filter);
 }
 
 .page-versions .version-menu {

--- a/docs/ui/src/css/toolbar.css
+++ b/docs/ui/src/css/toolbar.css
@@ -1,5 +1,6 @@
 .toolbar {
-  background-color: rgba(255, 255, 255, 0.1);
+  background-color: var(--toolbar-strip-bg);
+  border-bottom: 1px solid var(--toolbar-border-color);
   color: var(--toolbar-font-color);
   align-items: center;
   display: flex;

--- a/docs/ui/src/css/vars.css
+++ b/docs/ui/src/css/vars.css
@@ -64,11 +64,39 @@
   --heading-color: var(--mr-blue-600);
   --heading-strong-color: var(--text-strong);
 
-  /* Code surfaces stay Midnight in both themes (brand code panel). */
-  --code-panel-bg: var(--mr-code-bg);
-  --code-panel-fg: #adbac7;
-  --code-panel-border: rgba(148, 163, 184, 0.22);
+  /* Code block surface + syntax highlighting. Theme-aware: a light GitHub-
+     style surface in light mode, Midnight in dark mode, with the same hues in
+     both so the doc-comment feature reads the same way either way. */
+  --hl-bg: #f6f8fa;
+  --hl-fg: #1f2328;
+  --hl-comment: #6e7781;
+  --hl-keyword: #cf222e;
+  --hl-string: #0a3069;
+  --hl-const: #0550ae;
+  --hl-entity: #953800;
+  --hl-title: #8250df;
+  --hl-tag: #116329;
+  --hl-doc: #43711f;
+  --hl-doc-strong: #4d7c0f;
+  --hl-border: #d0d7de;
+  --code-panel-bg: var(--hl-bg);
+  --code-panel-fg: var(--hl-fg);
+  --code-panel-border: var(--hl-border);
   --code-panel-accent: var(--mr-blue);
+
+  /* Fill for the logo head silhouette (the line-work stays black either way).
+     Transparent on light leaves a black line drawing on the cream chrome;
+     white on dark fills the head so the black features read on top of it. */
+  --logo-fill: transparent;
+
+  /* Brand wordmark ("Mr.Docs") next to the head. Reuses the flipping text
+     colour so it is dark on the cream chrome and light on the midnight one. */
+  --logo-text-color: var(--color-white);
+
+  /* Monochrome white status icons (yes.svg/no.svg in tables, demo gallery)
+     load as <img>, so only a filter can recolour them: invert to dark on
+     the light theme, leave white on dark. */
+  --doc-icon-filter: invert(1);
 
   /* "text on surface" family — dark in light mode, flips white in dark mode.
      Component CSS uses these directly for foreground text. */
@@ -136,14 +164,31 @@
   --nav-muted-color: var(--text-muted);
   --nav-panel-divider-color: var(--border);
   --nav-secondary-background: var(--surface-2);
+  /* Left nav column: on light a solid panel surface set off from the cream
+     content; on dark a transparent base so the white overlays below keep the
+     current midnight look. The overlays flip to transparent on light so they
+     don't wash the panel back toward the content colour. */
+  --nav-panel-background: var(--surface-2);
+  --nav-panel-overlay: transparent;
+  --nav-explore-overlay: transparent;
 
   /* toolbar */
   --toolbar-background: var(--surface);
+  /* Breadcrumbs strip: on light a solid surface-2 band set off from the cream
+     content (matching the nav column); on dark the white overlay that lifts
+     the midnight page, as before. */
+  --toolbar-strip-bg: var(--surface-2);
   --toolbar-border-color: var(--border);
   --toolbar-font-color: var(--text-muted);
   --toolbar-muted-color: var(--text-muted);
   --page-version-menu-background: var(--surface-2);
   --page-version-missing-font-color: var(--text-muted);
+
+  /* Tabbed code cards (AsciiDoc tabs). Light paints solid surfaces set off
+     from the cream content; dark keeps the white/black overlays it had. */
+  --tab-surface: var(--surface-2);
+  --tab-inactive-bg: var(--slate-200);
+  --tab-inactive-color: var(--text-muted);
 
   /* admonitions (brand accents; readable on both themes) */
   --caution-color: var(--mr-pink);
@@ -283,6 +328,27 @@
   --color-black: rgba(0, 0, 0, 0.32);
   --color-blue-10: var(--mr-blue-300);
   --color-blue-100: var(--mr-blue);
+  --hl-bg: var(--mr-code-bg);
+  --hl-fg: #adbac7;
+  --hl-comment: #768390;
+  --hl-keyword: #f47067;
+  --hl-string: #96d0ff;
+  --hl-const: #6cb6ff;
+  --hl-entity: #f69d50;
+  --hl-title: #dcbdfb;
+  --hl-tag: #8ddb8c;
+  --hl-doc: rgb(94, 135, 79);
+  --hl-doc-strong: rgb(164, 181, 67);
+  --hl-border: rgba(148, 163, 184, 0.22);
+  --logo-fill: #fff;
+  --doc-icon-filter: none;
+  --nav-panel-background: transparent;
+  --nav-panel-overlay: rgba(255, 255, 255, 0.1);
+  --nav-explore-overlay: rgba(255, 255, 255, 0.3);
+  --toolbar-strip-bg: rgba(255, 255, 255, 0.1);
+  --tab-surface: rgba(255, 255, 255, 0.12);
+  --tab-inactive-bg: rgba(0, 0, 0, 0.25);
+  --tab-inactive-color: rgba(255, 255, 255, 0.5);
 }
 
 @media only screen and (prefers-color-scheme: dark) {
@@ -317,5 +383,26 @@
     --color-black: rgba(0, 0, 0, 0.32);
     --color-blue-10: var(--mr-blue-300);
     --color-blue-100: var(--mr-blue);
+    --hl-bg: var(--mr-code-bg);
+    --hl-fg: #adbac7;
+    --hl-comment: #768390;
+    --hl-keyword: #f47067;
+    --hl-string: #96d0ff;
+    --hl-const: #6cb6ff;
+    --hl-entity: #f69d50;
+    --hl-title: #dcbdfb;
+    --hl-tag: #8ddb8c;
+    --hl-doc: rgb(94, 135, 79);
+    --hl-doc-strong: rgb(164, 181, 67);
+    --hl-border: rgba(148, 163, 184, 0.22);
+    --logo-fill: #fff;
+    --doc-icon-filter: none;
+    --nav-panel-background: transparent;
+    --nav-panel-overlay: rgba(255, 255, 255, 0.1);
+    --nav-explore-overlay: rgba(255, 255, 255, 0.3);
+    --toolbar-strip-bg: rgba(255, 255, 255, 0.1);
+    --tab-surface: rgba(255, 255, 255, 0.12);
+    --tab-inactive-bg: rgba(0, 0, 0, 0.25);
+    --tab-inactive-color: rgba(255, 255, 255, 0.5);
   }
 }

--- a/docs/ui/src/css/vendor/tabs.css
+++ b/docs/ui/src/css/vendor/tabs.css
@@ -1,22 +1,22 @@
 @import "@asciidoctor/tabs";
 
 .tabpanel {
-  background-color: rgba(255, 255, 255, 0.1);
+  background-color: var(--tab-surface);
   backdrop-filter: blur(10px);
-  border: 1px solid rgba(255, 255, 255, 0.15);
+  border: 1px solid var(--border);
 }
 
 .tablist > ul li {
-  background-color: rgba(255, 255, 255, 0.15);
+  background-color: var(--tab-surface);
   backdrop-filter: blur(10px);
-  border: 1px solid rgba(255, 255, 255, 0.15);
+  border: 1px solid var(--border);
 }
 
 .tabs.is-loading .tablist li:not(:first-child),
 .tabs:not(.is-loading) .tablist li:not(.is-selected) {
-  background-color: rgba(0, 0, 0, 0.25);
+  background-color: var(--tab-inactive-bg);
   backdrop-filter: blur(10px);
-  color: rgba(255, 255, 255, 0.5);
+  color: var(--tab-inactive-color);
   opacity: 0.5;
 }
 

--- a/docs/ui/src/partials/logo.hbs
+++ b/docs/ui/src/partials/logo.hbs
@@ -2,13 +2,19 @@
 <svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1080 1080">
   <defs>
     <style>
-      .cls-1 {
-        stroke: #fff;
+      #Layer_1 .cls-1 {
+        stroke: currentColor;
         stroke-width: 2px;
       }
 
-      .cls-1, .cls-2 {
-        fill: #fff;
+      #Layer_1 .cls-1, #Layer_1 .cls-2 {
+        fill: currentColor;
+      }
+
+      #Layer_1 path:not(.cls-1):not(.cls-2),
+      #Layer_1 polygon, #Layer_1 polyline,
+      #Layer_1 circle, #Layer_1 ellipse, #Layer_1 rect {
+        fill: #000;
       }
     </style>
   </defs>

--- a/docs/website/index.html
+++ b/docs/website/index.html
@@ -51,13 +51,19 @@
 <svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1080 1080">
   <defs>
     <style>
-      .cls-1 {
-        stroke: #fff;
+      #Layer_1 .cls-1 {
+        stroke: currentColor;
         stroke-width: 2px;
       }
 
-      .cls-1, .cls-2 {
-        fill: #fff;
+      #Layer_1 .cls-1, #Layer_1 .cls-2 {
+        fill: currentColor;
+      }
+
+      #Layer_1 path:not(.cls-1):not(.cls-2),
+      #Layer_1 polygon, #Layer_1 polyline,
+      #Layer_1 circle, #Layer_1 ellipse, #Layer_1 rect {
+        fill: #000;
       }
     </style>
   </defs>

--- a/docs/website/styles.css
+++ b/docs/website/styles.css
@@ -175,6 +175,28 @@ kbd {
     color-scheme: light;
     --background-color: #fdfaf5;
     --body-background: #fdfaf5;
+    /* code + panel surfaces (light) */
+    --hl-bg: #f6f8fa;
+    --hl-fg: #1f2328;
+    --hl-comment: #6e7781;
+    --hl-keyword: #cf222e;
+    --hl-string: #0a3069;
+    --hl-const: #0550ae;
+    --hl-entity: #953800;
+    --hl-title: #8250df;
+    --hl-tag: #116329;
+    --hl-doc: #43711f;
+    --hl-doc-strong: #4d7c0f;
+    --panel-surface: #ffffff;
+    --panel-border: #d0d7de;
+    --panel-fg: #24303f;
+    --panel-link: #2563eb;
+    --logo-fill: transparent;
+    /* Literal, not var(--color): Pico reassigns --color to the blue link
+       colour on every <a>, and the wordmark lives inside the logo link. */
+    --logo-text-color: rgba(0, 0, 0, 0.8);
+    --box-outline: drop-shadow(0 0 2px rgba(15, 23, 42, 0.3));
+    --panel-title: #2563eb;
     --color: rgba(0, 0, 0, 0.8);
     --h1-color: rgba(0, 0, 0, 0.95);
     --h2-color: rgba(0, 0, 0, 0.9);
@@ -275,6 +297,26 @@ kbd {
     color-scheme: dark;
     --background-color: rgba(0, 0, 0, 0.3);
     --body-background: #0f172a;
+    /* code + panel surfaces (dark) */
+    --hl-bg: #0f172a;
+    --hl-fg: #adbac7;
+    --hl-comment: #768390;
+    --hl-keyword: #f47067;
+    --hl-string: #96d0ff;
+    --hl-const: #6cb6ff;
+    --hl-entity: #f69d50;
+    --hl-title: #dcbdfb;
+    --hl-tag: #8ddb8c;
+    --hl-doc: rgb(94, 135, 79);
+    --hl-doc-strong: rgb(164, 181, 67);
+    --panel-surface: #131c2e;
+    --panel-border: rgba(148, 163, 184, 0.18);
+    --panel-fg: rgba(237, 242, 249, 0.92);
+    --panel-link: #93c5fd;
+    --logo-fill: #fff;
+    --logo-text-color: rgba(255, 255, 255, 0.9);
+    --box-outline: drop-shadow(0 0 0 transparent);
+    --panel-title: #facc15;
     --color: rgba(255, 255, 255, 0.9);
     --h1-color: rgba(255, 255, 255, 0.98);
     --h2-color: rgba(255, 255, 255, 0.95);
@@ -1443,7 +1485,8 @@ pre {
 pre > code {
     display: block;
     padding: var(--spacing);
-		background-color: rgba(0, 0, 0, 0.55);
+    background-color: var(--hl-bg);
+    color: var(--hl-fg);
     font-size: 14px;
     line-height: var(--line-height);
     overflow-x: auto;
@@ -2713,7 +2756,7 @@ section#demo {
 
 .documentation-panel h4 {
     font-size: 0.8125rem;
-    color: #fff;
+    color: var(--panel-fg);
     margin: 0 0 0.375rem 0;
     font-weight: 600;
 }
@@ -2722,7 +2765,7 @@ section#demo {
 .documentation-panel span:not([class^="hljs-"]),
 .documentation-panel div {
     font-size: 0.875rem;
-    color: #fff;
+    color: var(--panel-fg);
 }
 
 .documentation-panel p {
@@ -2737,7 +2780,7 @@ section#demo {
 .documentation-panel table thead th,
 .documentation-panel table thead td {
     background-color: rgba(0, 0, 0, 0.1);
-    color: #fff;
+    color: var(--panel-fg);
     font-size: 0.8rem;
 }
 
@@ -2766,7 +2809,7 @@ section#demo {
 .documentation-panel .admonition h4 {
     font-size: 0.95rem;
     font-weight: 600;
-    color: #7ee0ff;
+    color: var(--panel-link);
     margin-bottom: 0.2em;
     letter-spacing: 0.01em;
 }
@@ -2789,18 +2832,18 @@ section#demo {
  */
 .hljs-comment,
 .hljs-quote {
-    color: #768390;
+    color: var(--hl-comment);
     font-style: italic;
 }
 
 .hljs-keyword,
 .hljs-formula {
-    color: #f47067;
+    color: var(--hl-keyword);
 }
 
 .hljs-string,
 .hljs-regexp {
-    color: #96d0ff;
+    color: var(--hl-string);
 }
 
 .hljs-number,
@@ -2812,7 +2855,7 @@ section#demo {
 .hljs-attribute,
 .hljs-template-variable,
 .hljs-meta {
-    color: #6cb6ff;
+    color: var(--hl-const);
 }
 
 .hljs-built_in,
@@ -2821,20 +2864,20 @@ section#demo {
 .hljs-title.class_,
 .hljs-name,
 .hljs-variable {
-    color: #f69d50;
+    color: var(--hl-entity);
 }
 
 .hljs-title,
 .hljs-function .hljs-title,
 .hljs-title.function_ {
-    color: #dcbdfb;
+    color: var(--hl-title);
 }
 
 .hljs-tag,
 .hljs-doctag,
 .hljs-selector-tag,
 .hljs-section {
-    color: #8ddb8c;
+    color: var(--hl-tag);
 }
 
 /*
@@ -2844,19 +2887,19 @@ section#demo {
  * feed the rendered documentation stand out.
  */
 .hljs-doc-comment {
-    color: rgb(94, 135, 79);
+    color: var(--hl-doc);
     font-style: italic;
 }
 
 .hljs-doc-comment .hljs-doctag {
-    color: rgb(164, 181, 67);
+    color: var(--hl-doc-strong);
     font-style: normal;
     font-weight: 700;
 }
 
 .hljs-doc-comment .hljs-name,
 .hljs-doc-comment .hljs-string {
-    color: rgb(164, 181, 67);
+    color: var(--hl-doc-strong);
     font-style: italic;
 }
 
@@ -2889,13 +2932,17 @@ html {
     height: 48px;
     width: auto;
     flex-shrink: 0;
-    color: var(--nav-logo-color);
+    /* Only the head silhouette follows this colour; the line-work is black in
+       the SVG. Transparent on light gives a black line drawing on the cream
+       chrome, white on dark fills the head under the black features. */
+    color: var(--logo-fill);
 }
 
 .nav .logo-text, .navbar-brand .navbar-item:first-child .logo-text {
+    font-family: var(--display-font);
     font-size: 18px;
     font-weight: 700;
-    color: #fff;
+    color: var(--logo-text-color);
     white-space: nowrap;
 }
 
@@ -2990,7 +3037,7 @@ ol a:focus {
 =========================== */
 
 .nav {
-    background-color: rgba(0, 0, 0, 0.2);
+    background-color: var(--nav-background-color);
     font-size: 16px;
     font-weight: bold;
     height: 3.5rem;
@@ -3023,7 +3070,11 @@ footer a:visited {
 .nav a:focus,
 footer a:hover,
 footer a:focus {
-    color: #fff;
+    /* Highlight toward the high-contrast colour, which flips per theme:
+       darker than the muted rest colour on the cream page, brighter on the
+       midnight one. A flat #fff highlighted correctly on dark but made links
+       vanish on light. */
+    color: var(--contrast);
     -webkit-text-decoration: none;
     text-decoration: none;
     transform: translateY(-1px);
@@ -3132,12 +3183,12 @@ footer a:focus {
 /***** cutout box rotations *****/
 .box0 {
     position: relative;
-    filter: drop-shadow(7px 10px 0px rgba(0, 0, 0, .7));
+    filter: drop-shadow(7px 10px 0px rgba(0, 0, 0, .7)) var(--box-outline);
 }
 
 .box90 {
     transform: rotate(90deg);
-    filter: drop-shadow(7px -10px 0px rgba(0, 0, 0, .7));
+    filter: drop-shadow(7px -10px 0px rgba(0, 0, 0, .7)) var(--box-outline);
 }
 
 .box90 .inner-box {
@@ -3146,7 +3197,7 @@ footer a:focus {
 
 .box180 {
     transform: rotate(180deg);
-    filter: drop-shadow(-7px -10px 0px rgba(0, 0, 0, .7));
+    filter: drop-shadow(-7px -10px 0px rgba(0, 0, 0, .7)) var(--box-outline);
 }
 
 .box180 .inner-box {
@@ -3155,7 +3206,7 @@ footer a:focus {
 
 .box270 {
     transform: rotate(270deg);
-    filter: drop-shadow(-7px 10px 0px rgba(0, 0, 0, .7));
+    filter: drop-shadow(-7px 10px 0px rgba(0, 0, 0, .7)) var(--box-outline);
 }
 
 .box270 .inner-box {
@@ -3484,28 +3535,28 @@ footer a {
 }
 
 /* -------------------------------------------------------------------------
-   Theme-consistency fixes. The page ships dark by default; these keep the
-   light toggle readable and keep code/reference surfaces on-brand (Midnight)
-   in BOTH themes, since the embedded MrDocs HTML and the syntax colours are
-   tuned for a dark surface.
+   Theme-aware code + reference surfaces. In light mode these use a light code
+   / card surface with dark syntax; in dark mode they keep the Midnight card.
+   Colours come from the --hl-* / --panel-* tokens in the theme blocks above.
    ------------------------------------------------------------------------- */
 
-/* Reference/snippet panels: solid Midnight cards in both themes. */
+/* Reference (generated-docs) card. */
 .documentation-panel {
-    background-color: #131c2e;
-    border: 1px solid rgba(148, 163, 184, 0.18);
-    color: rgba(237, 242, 249, 0.92);
+    background-color: var(--panel-surface);
+    border: 1px solid var(--panel-border);
+    color: var(--panel-fg);
     backdrop-filter: none;
 }
 
 .documentation-panel a {
-    color: #93c5fd;
+    color: var(--panel-link);
 }
 
-/* The little hero chip under the buttons is a dark pill in both themes. */
+/* Hero chip under the buttons: a subtle bordered pill in both themes. */
 .banner-snippet code {
-    color: #cbd5e1;
-    background-color: #131c2e;
+    color: var(--color);
+    background-color: var(--code-background-color);
+    border: 1px solid var(--muted-border-color);
 }
 
 /* Hero secondary ("Get started") outline button: readable on cream. */
@@ -3515,14 +3566,13 @@ footer a {
     border-color: #24303f;
 }
 
-/* All highlighted code on the landing sits on Midnight in both themes (the
-   syntax palette, incl. the green doc-comment feature, is tuned for dark). */
+/* All highlighted code sits on the theme code surface. */
 .hljs {
-    background-color: #0f172a;
-    color: #adbac7;
+    background-color: var(--hl-bg);
+    color: var(--hl-fg);
 }
 
-/* Keep the embedded reference-panel section labels legible on the dark card. */
+/* Reference-panel section labels use the card foreground. */
 .documentation-panel h1,
 .documentation-panel h2,
 .documentation-panel h3,
@@ -3532,15 +3582,14 @@ footer a {
 .documentation-panel small,
 .documentation-panel dt,
 .documentation-panel .paragraph {
-    color: rgba(237, 242, 249, 0.86);
+    color: var(--panel-fg);
 }
 
-/* Left raw-source snippet panel: a Midnight card that matches the border /
-   radius / padding of the generated-docs card beside it (its <code> carries
-   no .hljs class, only the inner token spans, so target the pre directly). */
+/* Left raw-source snippet: a code-surface card matching the docs card beside
+   it (its <code> carries no .hljs class, only inner token spans). */
 .snippet-panel > pre {
-    background-color: #131c2e;
-    border: 1px solid rgba(148, 163, 184, 0.18);
+    background-color: var(--hl-bg);
+    border: 1px solid var(--panel-border);
     border-radius: var(--border-radius);
     padding: 1rem;
     margin: 0;
@@ -3549,7 +3598,7 @@ footer a {
 
 .snippet-panel > pre,
 .snippet-panel > pre > code {
-    color: #adbac7;
+    color: var(--hl-fg);
 }
 
 .snippet-panel > pre > code {
@@ -3600,14 +3649,16 @@ footer a {
     border: 0;
     width: auto;
     background: transparent;
-    color: var(--contrast);
+    /* Match the github icon / nav links: muted grey at rest, brightening on
+       hover, rather than the high-contrast near-black/near-white of --contrast. */
+    color: var(--muted-color);
     cursor: pointer;
     line-height: 1;
     transition: color var(--transition), transform var(--transition);
 }
 
 .theme-toggle-btn:hover {
-    color: var(--primary);
+    color: var(--contrast);
     transform: translateY(-1px);
     background: transparent;
 }
@@ -3648,4 +3699,22 @@ footer a {
 .documentation-panel,
 .snippet-documentation-panel {
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+}
+
+/* -------------------------------------------------------------------------
+   More light-mode fixes.
+   ------------------------------------------------------------------------- */
+
+/* The "Star us on GitHub" band is forced light; give it a surface distinct
+   from the cream page so it reads as a separate strip in both page themes. */
+#star {
+    background-color: #eef1f5;
+    border-top: 1px solid #d7dde5;
+    border-bottom: 1px solid #d7dde5;
+}
+
+/* Symbol-name title keeps a brand accent that reads in both themes. */
+.documentation-panel h2,
+.documentation-panel h2 a {
+    color: var(--panel-title);
 }


### PR DESCRIPTION
This PR brings light mode up to the same level as dark mode on both the documentation site and the landing page

## Changes

A handful of components still used parameters from dark mode. Those are now variables. It mostly includes changes to code blocks, previews, the logo, small icons, and the navbars. Dark mode looks the same as before.

## Testing

Visual inspection. There's nothing automated to add.

## Documentation

None needed. This is the documentation site's own styling.