### PR TITLE
fix: define MRDOCS_NO_UNIQUE_ADDRESS and MRDOCS_DOM_NO_UNIQUE_ADDRESS correctly

### DIFF
--- a/include/mrdocs/Platform.hpp
+++ b/include/mrdocs/Platform.hpp
@@ -5,6 +5,7 @@
 //
 // Copyright (c) 2023 Vinnie Falco (vinnie.falco@gmail.com)
 // Copyright (c) 2023 Alan de Freitas (alandefreitas@gmail.com)
+// Copyright (c) 2026 Gennaro Prota (gennaro.prota@gmail.com)
 //
 // Official repository: https://github.com/cppalliance/mrdocs
 //
@@ -78,8 +79,10 @@ namespace mrdocs {
 #endif
 
 #ifndef MRDOCS_NO_UNIQUE_ADDRESS
-# if defined(__cpp_lib_no_unique_address)
+# if __has_cpp_attribute(no_unique_address)
 #  define MRDOCS_NO_UNIQUE_ADDRESS [[no_unique_address]]
+# elif __has_cpp_attribute(msvc::no_unique_address)
+#  define MRDOCS_NO_UNIQUE_ADDRESS [[msvc::no_unique_address]]
 # else
 #  define MRDOCS_NO_UNIQUE_ADDRESS
 # endif

--- a/libs/dom/include/mrdocs/Dom/Platform.hpp
+++ b/libs/dom/include/mrdocs/Dom/Platform.hpp
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // Copyright (c) 2023 Alan de Freitas (alandefreitas@gmail.com)
+// Copyright (c) 2026 Gennaro Prota (gennaro.prota@gmail.com)
 //
 // Official repository: https://github.com/cppalliance/mrdocs
 //
@@ -34,8 +35,10 @@
 # define MRDOCS_DOM_DECL
 #endif
 
-#if defined(__cpp_lib_no_unique_address)
+#if __has_cpp_attribute(no_unique_address)
 # define MRDOCS_DOM_NO_UNIQUE_ADDRESS [[no_unique_address]]
+#elif __has_cpp_attribute(msvc::no_unique_address)
+# define MRDOCS_DOM_NO_UNIQUE_ADDRESS [[msvc::no_unique_address]]
 #else
 # define MRDOCS_DOM_NO_UNIQUE_ADDRESS
 #endif


### PR DESCRIPTION
The macro definitions were guarded by `__cpp_lib_no_unique_address`, which does not exist, so they expanded to nothing on all compilers. Also, MSVC has its own version of the attribute (`msvc::no_unique_address`) and does not support the standard one.

## Changes

- **Source**: For both macros, `__has_cpp_attribute` is used to select the correct definition.

## Testing

We don't usually test macro definitions like those.

## Documentation

The macros are implementation details, so no documentation update is needed.