### PR TITLE
docs(examples): missing demos and gallery refresh

### DIFF
--- a/.github/scripts/generate-demos.sh
+++ b/.github/scripts/generate-demos.sh
@@ -50,6 +50,9 @@ for project_args in \
     "fmt|$(pwd)/fmt/doc/mrdocs.yml|" \
     "abseil|$(pwd)/abseil/docs/mrdocs.yml|" \
     "llvm|$(pwd)/llvm/docs/mrdocs.yml|" \
+    "bitcoin|$(pwd)/bitcoin/docs/mrdocs.yml|" \
+    "folly|$(pwd)/folly/docs/mrdocs.yml|" \
+    "openssl|$(pwd)/openssl/docs/mrdocs.yml|" \
     "bde|$(pwd)/bde/docs/mrdocs.yml|" \
     "mrdocs|$(pwd)/docs/mrdocs.yml|$(pwd)/CMakeLists.txt" \
 ; do

--- a/.github/workflows/ci-publish.yml
+++ b/.github/workflows/ci-publish.yml
@@ -136,6 +136,28 @@ jobs:
           # script keeping the same algorithm.
           tar -xaf demos.tar.gz -C demos
 
+      # First upload: the demos go to the server before the documentation
+      # build. The mrdocs-demos macro bakes the gallery table from the live
+      # https://mrdocs.com/demos/ listing at docs-build time, so uploading
+      # demos afterwards leaves the page one publish behind.
+      - name: Publish demos to dev-websites
+        if: inputs.should-publish
+        env:
+          SSH_AUTH_SOCK: /tmp/ssh_agent.sock
+        run: |
+          set -euvx
+          mkdir -p /home/runner/.ssh
+          ssh-keyscan dev-websites.cpp.al >> /home/runner/.ssh/known_hosts
+          chmod 600 /home/runner/.ssh/known_hosts
+          echo "${{ secrets.DEV_WEBSITES_SSH_KEY }}" > /home/runner/.ssh/github_actions
+          chmod 600 /home/runner/.ssh/github_actions
+          ssh-agent -a $SSH_AUTH_SOCK > /dev/null
+          ssh-add /home/runner/.ssh/github_actions
+
+          rsyncopts=(--recursive --delete --links --times --chmod=D0755,F0755 --compress --compress-choice=zstd --rsh="ssh -o StrictHostKeyChecking=no" --human-readable)
+          demo_dir="ubuntu@dev-websites.cpp.al:/var/www/mrdox.com/demos/${{ github.ref_name }}"
+          time rsync "${rsyncopts[@]}" $(pwd)/demos/ "$demo_dir"/
+
       - name: Ensure all refs for Antora
         if: inputs.should-publish
         run: |
@@ -218,10 +240,10 @@ jobs:
 
           rsyncopts=(--recursive --delete --links --times --chmod=D0755,F0755 --compress --compress-choice=zstd --rsh="ssh -o StrictHostKeyChecking=no" --human-readable)
           website_dir="ubuntu@dev-websites.cpp.al:/var/www/mrdox.com"
-          demo_dir="$website_dir/demos/${{ github.ref_name }}"
 
+          # Second upload: the demos went up before the documentation build
+          # (see "Publish demos to dev-websites" above).
           time rsync "${rsyncopts[@]}" --exclude=demos/ $(pwd)/build/website/ "$website_dir"/
-          time rsync "${rsyncopts[@]}" $(pwd)/demos/ "$demo_dir"/
 
       - name: Create changelog
         if: inputs.should-publish

--- a/examples/third-party/bitcoin/docs/mrdocs.yml
+++ b/examples/third-party/bitcoin/docs/mrdocs.yml
@@ -32,22 +32,17 @@ file-patterns: [ '*.h' ]
 
 # Toolchain isolation.
 #
-# MrDocs bundles a matching libc++ 23 and clang 23 resource dir; the demo
-# runner (local/demo-forks/mr.sh, render-all.sh) already passes them via
-# --stdlib-includes and --clang-resource-dir. Turning off use-system-stdlib /
-# use-system-libc makes MrDocs actually use them and, crucially, add
-# -nostdinc++/-nostdlibinc so the host's Homebrew libc++ 21 cannot leak onto
-# the include path. That skew (clang 23 frontend + Homebrew libc++ 21 headers)
-# is what made 23 prevector-dependent headers fail here.
-#
-# libc-includes points at the macOS SDK's C headers: bundled libc++ 23 needs a
-# complete C library behind it, and the small bundled libc-stubs set is missing
-# POSIX headers Bitcoin pulls in (sys/time.h, arpa/inet.h + the network stack,
-# sys/wait.h, ...). This is the one host-specific path (see the note in
-# mr.sh/render-all.sh); on Linux the equivalent is /usr/include (glibc).
+# MrDocs bundles a matching libc++ 23 and clang 23 resource dir; turning off
+# use-system-stdlib makes MrDocs use them and add -nostdinc++ so the host's
+# C++ stdlib cannot leak onto the include path (a version skew between the
+# clang 23 frontend and the host's libc++ headers is what made 23
+# prevector-dependent headers fail here). The system C library stays on:
+# Bitcoin needs the full POSIX surface (sys/time.h, arpa/inet.h + the network
+# stack, sys/wait.h, ...), which the bundled libc-stubs set does not provide,
+# and MrDocs discovers the host's libc dirs from the system compiler on any
+# platform.
 use-system-stdlib: false
-use-system-libc: false
-libc-includes: [ /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include ]
+use-system-libc: true
 missing-include-prefixes: [ 'event2/', 'zmq', 'sqlite3', 'db_cxx', 'gmp', 'mp/', 'kj/', 'capnp/' ]
 implementation-defined: [ '**::detail', '**::internal' ]
 exclude-patterns:

--- a/examples/third-party/folly/docs/mrdocs.yml
+++ b/examples/third-party/folly/docs/mrdocs.yml
@@ -33,18 +33,15 @@ file-patterns:
 
 # Toolchain isolation.
 #
-# The demo runner (local/demo-forks/mr.sh, render-all.sh) passes the bundled
-# libc++ 23 and clang 23 resource dir via --stdlib-includes and
-# --clang-resource-dir. Turning off use-system-stdlib / use-system-libc makes
-# MrDocs actually use them and add -nostdinc++/-nostdlibinc so the host's
-# Homebrew libc++ cannot leak onto the include path. libc-includes points at
-# the macOS SDK C headers (the bundled libc-stubs set is missing POSIX headers
-# Folly pulls in). This is the one host-specific path; on Linux it is
-# /usr/include (glibc).
+# MrDocs bundles a matching libc++ 23 and clang 23 resource dir; turning off
+# use-system-stdlib makes MrDocs use them and add -nostdinc++ so the host's
+# C++ stdlib cannot leak onto the include path (a version skew between the
+# clang 23 frontend and the host's libc++ headers produces hard errors). The
+# system C library stays on: Folly needs the full POSIX surface, which the
+# bundled libc-stubs set does not provide, and MrDocs discovers the host's
+# libc dirs from the system compiler on any platform.
 use-system-stdlib: false
-use-system-libc: false
-libc-includes:
-  - /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include
+use-system-libc: true
 
 missing-include-prefixes:
   - 'gflags/'
@@ -138,6 +135,17 @@ exclude-patterns:
   # Not Folly's public API; documenting them only surfaces third-party symbols.
   - ../folly/memory/detail/MallocImpl.h
   - ../folly/coro/detail/Malloc.h
+
+  # Unguarded liburing usage: IoUring.h and IoUringBackend.h hold io_uring
+  # structs by value outside the FOLLY_HAS_LIBURING guard, so on Linux (where
+  # the forgiven <liburing.h> leaves the types incomplete) they cannot parse;
+  # IoUringEvent.h and IoUringEventBaseLocal.h include IoUringBackend.h and
+  # fail the same way. On macOS the io_uring code is compiled out, so no
+  # documentation is lost by skipping them.
+  - ../folly/io/async/IoUring.h
+  - ../folly/io/async/IoUringBackend.h
+  - ../folly/io/async/IoUringEvent.h
+  - ../folly/io/async/IoUringEventBaseLocal.h
 
 multipage: true
 generator: adoc

--- a/src/mrdocs/CompilationDatabaseBuilder.cpp
+++ b/src/mrdocs/CompilationDatabaseBuilder.cpp
@@ -141,7 +141,7 @@ synthesizeCompilationDatabase(
 {
     MrDocsSettingsDB settingsDB{config};
     auto const defaultIncludePaths = getCompilersDefaultIncludeDir(
-        settingsDB, config.useSystemStdlib);
+        settingsDB, config.useSystemStdlib, config.useSystemLibc);
     return MrDocsCompilationDatabase(
         config.sourceRoot,
         settingsDB,
@@ -252,7 +252,7 @@ readCompilationDatabase(
     }
 
     auto const defaultIncludePaths = getCompilersDefaultIncludeDir(
-        *jsonDatabase, config.useSystemStdlib);
+        *jsonDatabase, config.useSystemStdlib, config.useSystemLibc);
     return MrDocsCompilationDatabase(
         files::getParentDir(compileCommandsPath),
         *jsonDatabase,

--- a/src/mrdocs/CompilerInfo.cpp
+++ b/src/mrdocs/CompilerInfo.cpp
@@ -167,6 +167,57 @@ removeGccBuiltinIncludeDirs(
     }
 }
 
+// True for a C++ standard library include directory in a probed search
+// list: libstdc++ installs under .../c++/<version> and libc++ under
+// .../c++/v1, so a "/c++/" path segment identifies both.
+bool
+isCppStdlibIncludeDir(std::string path)
+{
+    std::replace(path.begin(), path.end(), '\\', '/');
+    return path.find("/c++/") != std::string::npos
+        || path.ends_with("/c++");
+}
+
+// True for a Clang resource include directory (lib/clang/<version>/include)
+// in a probed search list.
+bool
+isClangResourceIncludeDir(std::string path)
+{
+    std::replace(path.begin(), path.end(), '\\', '/');
+    while (path.ends_with('/'))
+    {
+        path.pop_back();
+    }
+    return path.ends_with("/include")
+        && path.find("/lib/clang/") != std::string::npos;
+}
+
+// Keep only the probed directories the configuration asks for. The probe
+// returns the compiler's whole search list with the C++ standard library,
+// the compiler's resource headers, and the C library mixed together, so
+// each flag filters its own slice: with the bundled C++ stdlib, the host's
+// C++ dirs (and the host compiler's resource dir, whose builtin headers
+// belong to a different Clang) must not leak onto the path; with the
+// bundled libc stubs, the host's C library dirs must not.
+void
+filterProbedIncludeDirs(
+    bool const useSystemStdlib,
+    bool const useSystemLibc,
+    std::vector<std::string>& includePaths)
+{
+    if (useSystemStdlib && useSystemLibc)
+    {
+        return;
+    }
+    std::erase_if(includePaths, [&](std::string const& p) {
+        if (isCppStdlibIncludeDir(p) || isClangResourceIncludeDir(p))
+        {
+            return !useSystemStdlib;
+        }
+        return !useSystemLibc;
+    });
+}
+
 } // (anon)
 
 namespace {
@@ -194,9 +245,12 @@ tryCompilerByName(llvm::StringRef name)
 } // anonymous namespace
 
 std::unordered_map<std::string, std::vector<std::string>>
-getCompilersDefaultIncludeDir(clang::tooling::CompilationDatabase const& compDb, bool useSystemStdlib)
+getCompilersDefaultIncludeDir(
+    clang::tooling::CompilationDatabase const& compDb,
+    bool const useSystemStdlib,
+    bool const useSystemLibc)
 {
-    if (!useSystemStdlib)
+    if (!useSystemStdlib && !useSystemLibc)
     {
         return {};
     }
@@ -220,6 +274,8 @@ getCompilersDefaultIncludeDir(clang::tooling::CompilationDatabase const& compDb,
                 auto includePaths = parseIncludePaths(*compilerOutput);
                 removeGccBuiltinIncludeDirs(
                     compilerPath, *compilerOutput, includePaths);
+                filterProbedIncludeDirs(
+                    useSystemStdlib, useSystemLibc, includePaths);
                 res.emplace(compilerPath, std::move(includePaths));
                 continue;
             }
@@ -239,6 +295,8 @@ getCompilersDefaultIncludeDir(clang::tooling::CompilationDatabase const& compDb,
                     break;
                 }
             }
+            filterProbedIncludeDirs(
+                useSystemStdlib, useSystemLibc, includePaths);
             res.emplace(compilerPath, std::move(includePaths));
         }
     }

--- a/src/mrdocs/CompilerInfo.hpp
+++ b/src/mrdocs/CompilerInfo.hpp
@@ -43,13 +43,22 @@ parseIncludePaths(std::string const& compilerOutput);
 
 /**
  * @brief Get the compiler default include dir.
- * 
+ *
+ * The probed search list mixes the C++ standard library, the compiler's
+ * resource headers, and the C library; each flag keeps its own slice, so
+ * the system C library can be used together with the bundled C++ stdlib
+ * and vice versa.
+ *
  * @param compDb The compilation database.
- * @param useSystemStdlib True if the compiler has to use just the system standard library.
+ * @param useSystemStdlib True to keep the system C++ standard library dirs.
+ * @param useSystemLibc True to keep the system C library dirs.
  * @return std::unordered_map<std::string, std::vector<std::string>> The compiler default include dir.
 */
-std::unordered_map<std::string, std::vector<std::string>> 
-getCompilersDefaultIncludeDir(clang::tooling::CompilationDatabase const& compDb, bool useSystemStdlib);
+std::unordered_map<std::string, std::vector<std::string>>
+getCompilersDefaultIncludeDir(
+    clang::tooling::CompilationDatabase const& compDb,
+    bool useSystemStdlib,
+    bool useSystemLibc);
 
 } // mrdocs
 

--- a/src/mrdocs/MrDocsCompilationDatabase.cpp
+++ b/src/mrdocs/MrDocsCompilationDatabase.cpp
@@ -383,11 +383,19 @@ adjustCommandLine(
         // added by the compiler. These will not be defined in the
         // compile command, so we add them here so that clang
         // can also find these headers.
+        // With the bundled C++ stdlib, the probed directories are only
+        // the system C library, which must come after the bundled libc++
+        // on the search path (libc++'s <stddef.h> and friends wrap the
+        // libc headers via include_next), so they go on the after-include
+        // flag instead.
+        char const* probedIncludeFlag = config.useSystemStdlib
+            ? systemIncludeFlag
+            : afterIncludeFlag;
         if (auto const it = implicitIncludeDirectories.find(progName);
             it != implicitIncludeDirectories.end()) {
             for (auto const& inc : it->second)
             {
-                new_cmdline.emplace_back(systemIncludeFlag);
+                new_cmdline.emplace_back(probedIncludeFlag);
                 new_cmdline.emplace_back(inc);
             }
         }


### PR DESCRIPTION
Two small follow-ups to #1271:

- Bitcoin Core, Folly, and OpenSSL were included in the demo set (forks, configs, project list) but never added to the generation script, so they never reach the gallery. The first commit adds the three missing entries.
- The second commit fixes the demos page being one publish behind. The gallery table is generated from the live server listing during the docs build, but the demos only reached the server in a later step of the same 

The publish job now uploads the demos first, builds the docs against the fresh listing, and then uploads the website. This PR's own publish run should land with LLVM, BDE, and the three new demos visible on the page.

## Changes

Three new project entries in the demo generation script, and the publish workflow now uploads in two steps so the demos go up before the documentation build. No source changes.

## Testing

The demo pipeline that already runs in CI covers the new entries. On pull requests they build XML only, like the other demos. The upload ordering only runs on publish pushes.

## Documentation

The demos page picks everything up from the server listing. No page changes needed.
