### PR TITLE
feat(tools): fix-docs documentation tool

### DIFF
--- a/docs/modules/ROOT/pages/generators/noop.adoc
+++ b/docs/modules/ROOT/pages/generators/noop.adoc
@@ -67,3 +67,8 @@ include::example$examples/generators/noop/fix-loop/fix-docs.py[]
 ----
 
 This pattern can be used to give a project a baseline of documentation.
+
+[TIP]
+====
+The example above is intentionally small. A larger "pro" version ships in `tools/fix-docs` with a number of optimizations.
+====

--- a/examples/generators/noop/fix-loop/README.md
+++ b/examples/generators/noop/fix-loop/README.md
@@ -34,3 +34,5 @@ There is no CTest target here: the loop needs a real agent to make progress, so
 it cannot run unattended in CI.
 
 See `generators/noop.adoc` in the documentation for the full write-up.
+
+This example is deliberately small. A larger "pro" version of the same idea lives in `tools/fix-docs` with a number of optimizations.

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,16 +1,22 @@
 # tools/
 
-Executables built on top of the mrdocs library. Tools *depend on* the library
-(`libs/` is the opposite: libraries the project depends on). Keeping tools here
-is what lets `src/` hold the library and nothing else.
+User-facing tools built on mrdocs (`libs/` is the opposite: libraries the
+project depends on). Most link the mrdocs library and consume its public API,
+but a tool can also be a script that drives the `mrdocs` executable. Either
+way, tools are meant for the project's users, unlike `utils/`, which holds
+developer and build tooling the project never ships.
 
 ## Layout
-- `tools/<tool>/` is one tool with its own recursive layout: its own
-  `src/`, its own `CMakeLists.txt`, and optionally its own `tests/`.
-- A tool consumes the library through its public API (`<mrdocs/...>`). Reaching
-  into library private headers is a smell to promote-or-refactor.
+- `tools/<tool>/` is one tool. A compiled tool has its own recursive layout:
+  its own `src/`, its own `CMakeLists.txt`, and optionally its own `tests/`.
+  A script tool is just its files, with no build step.
+- A compiled tool consumes the library through its public API (`<mrdocs/...>`).
+  Reaching into library private headers is a smell to promote-or-refactor.
 
 ## Tools
 - `mrdocs/` — the command-line documentation generator (the `mrdocs`
   executable). Its target is defined locally in `tools/mrdocs/CMakeLists.txt`
   and wired in from the root via `add_subdirectory`.
+- `fix-docs/` — a Python tool that drives an AI agent and the `mrdocs`
+  executable to bring a project's documentation up to date. See
+  `tools/fix-docs/README.md`.

--- a/tools/fix-docs/.gitignore
+++ b/tools/fix-docs/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/tools/fix-docs/README.md
+++ b/tools/fix-docs/README.md
@@ -1,0 +1,99 @@
+# fix-docs
+
+Drives an AI agent to bring a project's documentation up to date.
+
+> The didactic version of this idea lives in `examples/generators/noop/fix-loop`
+and stays small on purpose. This tool is the one that grows features.
+
+## Phases
+
+### 1. Compile
+
+Extraction runs the `json` generator with warnings off and no error cap. While translation units fail to compile, the agent gets the compiler errors and fixes the config and shims until the whole project extracts. The corpus from the successful run is handed to the document phase, so a clean project is never extracted twice.
+
+### 2. Document
+
+The work-list is derived from that JSON file. It covers every problem the strict check can find offline: 
+
+- undocumented symbols, 
+- missing briefs, 
+- anomalous briefs (description paragraphs or banners picked up as briefs), 
+- function parameters with no `@param`, 
+- unnamed parameters (the agent names them so they can be documented), 
+- undocumented namespaces, and 
+- undocumented enum values. 
+ 
+Tasks are ordered the way the index is: global namespace first (macros included), then one namespace level, then two, and alphabetically within a level. Files are visited in that order, so an interrupted run still leaves everything a reader sees first fully documented.
+ 
+The driver groups tasks by file and hands the agent one file's complete list per call, so line drift stays inside a single visit and it can print progress and an ETA. Within a file the tasks are listed bottom to top (highest line number first), so each edit the agent makes never shifts the line numbers of the symbols it has not reached yet. 
+
+Mr.Docs re-runs only between cycles, not between files. Progress is checkpointed to `fix-docs-state.json`, so an interrupted run resumes where it stopped.
+
+### 3. Warnings
+ 
+A strict check runs once and every diagnostic block is collected. Every warning is treated as an error. An inner loop feeds them to the agent batch by batch. Mr.Docs re-runs only when the collected list is exhausted. The outer loop stops when Mr.Docs finds no documentation errors.
+
+After the document phase, this is a backstop: it catches what needs extraction to see (documentation parse errors, broken references) and anything the offline pass got wrong.
+
+## Usage
+
+```bash
+cd path/to/project
+MRDOCS=/path/to/mrdocs AGENT="claude -p" \
+python3 /path/to/mrdocs/tools/fix-docs/fix-docs.py docs/mrdocs.yml \
+  --addons=... --stdlib-includes=... --libc-includes=... --clang-resource-dir=...
+```
+
+The first positional argument is the config. Everything the tool does not
+recognize is forwarded to every mrdocs invocation (any `--max-errors` is
+stripped), which is how the include and addon flags above reach mrdocs.
+
+The same run with flags instead of environment variables:
+
+```bash
+cd path/to/project
+python3 /path/to/mrdocs/tools/fix-docs/fix-docs.py docs/mrdocs.yml \
+  --mrdocs /path/to/mrdocs --agent "claude -p" --parallel 8 \
+  --addons=... --stdlib-includes=... --libc-includes=... --clang-resource-dir=...
+```
+
+Each option can be a command-line flag or an environment variable. A flag
+wins over its variable, and the variable wins over the default. Run with
+`--help` for the full list.
+
+- `--mrdocs` (env `MRDOCS`): the mrdocs binary (default: `mrdocs` on PATH).
+- `--agent` (env `AGENT`): the agent's non-interactive command, run with the
+  rendered prompt as its final argument (default `agent -p -f`, or
+  `claude -p` for Claude Code, `codex exec` for Codex).
+- `--parallel` (env `PARALLEL`): concurrent agents in the document phase
+  (default 1). File batches are independent, so this scales until the machine
+  runs out of cores or the agent runs out of rate limit.
+- `--batch` (env `BATCH`): diagnostic blocks per agent call in the warnings
+  phase (default 30).
+- `--max-rounds` (env `MAX_ROUNDS`): how many times mrdocs may re-run in the
+  compile and warnings phases (default 40). It never limits the fan-out
+  between runs: in the document phase every file in the work-list gets its
+  agent visit.
+- `--cycles` (env `CYCLES`): dump/fan-out passes in the document phase
+  (default 3). A task that survives this many full passes means the agent is
+  not converging.
+- `--state` (env `STATE`): checkpoint path. The default is under the system
+  temp directory, keyed by the config's absolute path, so it survives an
+  interrupted run without ever landing in the project tree.
+
+Prompts live in `prompts/` and are the place to teach the agent new repair
+strategies.
+
+## The work-list
+
+The `json` generator writes `reference.json`, and the work-list is derived
+from it in the driver. The rules that decide what needs work live in
+`fix-docs.py`: `classify` turns each symbol into its tasks (skip non-regular
+extraction, require a location), and `brief_anomaly` flags a brief that was
+never meant as one (too short, too long, mostly punctuation, a run of
+repeated punctuation). To change or add a rule, edit those functions.
+
+The dump reflects the same config and flags as every other phase, so nothing
+is copied or patched into the target project. The compile phase already runs
+the `json` generator, so its corpus is reused for the first document cycle.
+The warnings phase runs `--generator=noop`.

--- a/tools/fix-docs/fix-docs.py
+++ b/tools/fix-docs/fix-docs.py
@@ -1,0 +1,556 @@
+#!/usr/bin/env python3
+"""Drive an AI agent to fix a project's documentation with Mr.Docs, in three
+phases that minimize how often Mr.Docs has to run.
+
+Phase 1, compile: run extraction (no warnings, no max-errors) and hand the
+agent the compiler errors until the whole project extracts.
+
+Phase 2, document: dump the corpus once with Mr.Docs' JSON generator, derive
+the work-list from it (undocumented symbols, missing briefs, anomalous
+briefs), group it by file, and hand the agent one file's complete task list
+at a time. No Mr.Docs runs between files, so this phase also knows exactly
+how much work remains and estimates completion.
+
+Phase 3, warnings: run the strict check without max-errors, collect every
+diagnostic, feed them to the agent batch by batch in an inner loop, and only
+re-run Mr.Docs when the collected list is exhausted.
+
+The first argument is the config file; anything else is forwarded to every
+mrdocs run. Options (--mrdocs, --agent, --parallel, --batch, --max-rounds,
+--cycles, --state) each fall back to an environment variable (MRDOCS, AGENT,
+PARALLEL, BATCH, MAX_ROUNDS, CYCLES, STATE) then a default. Run with --help
+for the full list. The caps bound mrdocs re-runs, never the per-file or
+per-batch fan-out between runs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shlex
+import subprocess
+import sys
+import tempfile
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+from threading import Lock
+
+HERE = Path(__file__).resolve().parent
+
+
+def default_state_path(config):
+    """Checkpoint under the system temp dir, keyed by the config's absolute
+    path. It persists across interruptions so a resumed run finds it, but
+    never lands in the project tree where it would clutter git status."""
+    slug = re.sub(r"[^A-Za-z0-9]+", "-", str(Path(config).resolve())).strip("-")
+    return Path(tempfile.gettempdir()) / "fix-docs" / f"{slug}.json"
+
+
+def parse_args():
+    """Parse the command line. Every option falls back to its environment
+    variable, then to a default. Any argument we do not recognize is
+    forwarded verbatim to every mrdocs invocation (include dirs, addons, and
+    so on). allow_abbrev is off so a forwarded flag is never mistaken for a
+    prefix of one of ours."""
+    env = os.environ.get
+    p = argparse.ArgumentParser(
+        prog="fix-docs", allow_abbrev=False,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description="Drive an AI agent to document a project with Mr.Docs.",
+        epilog="Any other arguments are forwarded to every mrdocs run.")
+    p.add_argument("config", nargs="?", default="mrdocs.yml",
+                   help="the mrdocs config file (default: mrdocs.yml)")
+    p.add_argument("--mrdocs", default=env("MRDOCS", "mrdocs"),
+                   help="mrdocs binary (env MRDOCS; default: mrdocs on PATH)")
+    p.add_argument("--agent", default=env("AGENT", "agent -p -f"),
+                   help="agent command; the prompt is appended as its last "
+                        "argument (env AGENT; default: 'agent -p -f')")
+    p.add_argument("--parallel", type=int, default=int(env("PARALLEL", "1")),
+                   help="concurrent agents in the document phase "
+                        "(env PARALLEL; default: 1)")
+    p.add_argument("--batch", type=int, default=int(env("BATCH", "30")),
+                   help="diagnostics per agent call in the warnings phase "
+                        "(env BATCH; default: 30)")
+    p.add_argument("--max-rounds", type=int,
+                   default=int(env("MAX_ROUNDS", "40")),
+                   help="mrdocs re-run cap in the compile and warnings phases "
+                        "(env MAX_ROUNDS; default: 40)")
+    p.add_argument("--cycles", type=int, default=int(env("CYCLES", "3")),
+                   help="dump/fan-out passes in the document phase "
+                        "(env CYCLES; default: 3)")
+    p.add_argument("--state", default=env("STATE"),
+                   help="checkpoint path (env STATE; default: under the "
+                        "system temp dir, keyed by the config path)")
+    return p.parse_known_args()
+
+
+ARGS, EXTRA = parse_args()
+MRDOCS = ARGS.mrdocs
+AGENT = shlex.split(ARGS.agent)
+PARALLEL = ARGS.parallel
+BATCH = ARGS.batch
+MAX_ROUNDS = ARGS.max_rounds
+CYCLES = ARGS.cycles
+CONFIG = ARGS.config
+EXTRA = [a for a in EXTRA if not a.startswith("--max-errors")]
+STATE_PATH = Path(ARGS.state) if ARGS.state else default_state_path(CONFIG)
+
+# The strict lint set for phase 3. Phases 1 and 2 run with warnings off.
+STRICT = [
+    "--warnings", "--warn-if-undocumented", "--warn-no-paramdoc",
+    "--warn-unnamed-param", "--warn-if-undoc-enum-val", "--warn-if-doc-error",
+    "--warn-broken-ref", "--warn-if-undocumented-namespace",
+    "--warn-no-brief", "--warn-as-error",
+]
+
+ANSI = re.compile(r"\x1b\[[0-9;]*m")
+LOCATION = re.compile(r"^\S.*:\d+:\d+:\s*$")
+FOOTER = re.compile(
+    r"^(An issue occurred|If you believe|\s*MrDocs Version|\s*Error Location|"
+    r"\s*Reported From|with the following details|error limit reached)")
+
+
+def main():
+    print(f"config={CONFIG} agent={shlex.join(AGENT)} parallel={PARALLEL}")
+    corpus = phase_compile()
+    if corpus is None:
+        return 1
+    if not phase_document(corpus):
+        return 1
+    if not phase_warnings():
+        return 1
+    print("All three phases are clean.")
+    return 0
+
+
+# -------- shared helpers
+
+def run_mrdocs(args):
+    """Run mrdocs; return (returncode, ansi-stripped combined output)."""
+    cmd = [MRDOCS, f"--config={CONFIG}", *EXTRA, *args]
+    run = subprocess.run(cmd, capture_output=True, text=True)
+    return run.returncode, ANSI.sub("", run.stdout + run.stderr), cmd
+
+
+def run_agent(prompt):
+    """Hand one rendered prompt to the agent; return (seconds, exit code).
+    A non-zero exit means the agent invocation itself failed (crash, bad
+    command, rate-limit abort), not that it ran but left work undone."""
+    start = time.monotonic()
+    result = subprocess.run(AGENT + [prompt])
+    return time.monotonic() - start, result.returncode
+
+
+# Printed when every agent in a phase failed to run. The work is real, so the
+# problem is the agent command, not the project: stop before the next phase so
+# the user can point --agent (or AGENT) at another tool.
+def agent_broken(phase):
+    print(f"[{phase}] every agent invocation failed (non-zero exit). The "
+          f"agent command looks broken or unavailable; stopping so you can "
+          f"switch agents (--agent / AGENT). Later phases will not run.",
+          file=sys.stderr)
+
+
+def render(name, **values):
+    text = (HERE / "prompts" / f"{name}.md").read_text(encoding="utf-8")
+    for key, value in values.items():
+        text = text.replace("{" + key + "}", str(value))
+    return text
+
+
+def load_state():
+    if STATE_PATH.exists():
+        return json.loads(STATE_PATH.read_text(encoding="utf-8"))
+    return {"documented": []}
+
+
+def save_state(state):
+    STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    STATE_PATH.write_text(json.dumps(state, indent=1), encoding="utf-8")
+
+
+# -------- phase 1: fix until it compiles
+
+def phase_compile():
+    """Extract with the JSON generator until the project compiles. Returns
+    the corpus from the successful run so phase 2 can reuse it instead of
+    extracting a second time, or None if it never compiled."""
+    for round in range(1, MAX_ROUNDS + 1):
+        code, corpus, out, cmd = extract_json()
+        errors = compile_errors(out)
+        if corpus is not None and corpus.get("symbols") and not errors:
+            print(f"[compile] clean after {round - 1} repair round(s).")
+            return corpus
+        if not errors:
+            errors = [out.strip()[-4000:] or "(no output)"]
+        print(f"[compile] round {round}: {len(errors)} error line(s); "
+              f"handing them to the agent.")
+        seconds, agent_code = run_agent(render(
+            "compile",
+            command=shlex.join(cmd),
+            config=CONFIG,
+            errors="\n".join(errors[:400])))
+        if agent_code != 0:
+            agent_broken("compile")
+            return None
+        print(f"[compile] agent took {seconds:.0f}s.")
+    print("[compile] out of rounds.", file=sys.stderr)
+    return None
+
+
+def compile_errors(out):
+    """Compiler diagnostics and the failure summary, one line each."""
+    return [line for line in out.splitlines()
+            if re.search(r"(fatal error|error):", line)
+            or "errors occurred" in line
+            or "Failed to run action" in line]
+
+
+# -------- phase 2: fix until everything is documented and not weird
+
+def phase_document(initial_corpus=None):
+    state = load_state()
+    for cycle in range(1, CYCLES + 1):
+        # The compile phase already extracted; reuse its corpus for cycle 1
+        # instead of extracting again just to say the same thing.
+        if cycle == 1 and initial_corpus is not None:
+            tasks = work_list_from(initial_corpus)
+        else:
+            tasks = dump_work_list()
+        done = set(map(tuple, state["documented"]))
+        by_file = {}
+        for t in tasks:
+            key = (t["file"], t["name"], t["reason"])
+            if key not in done:
+                by_file.setdefault(t["file"], []).append(t)
+        if not by_file:
+            print(f"[document] work-list clean after cycle {cycle - 1}.")
+            return True
+
+        # Do the files nearest the top of the index first, so an interrupted
+        # run still leaves everything a reader sees first fully documented. A
+        # file's priority is the best index rank among its tasks; the tasks
+        # are already sorted by rank, so the first one is that best.
+        ordered_files = sorted(
+            by_file.items(), key=lambda kv: index_rank(kv[1][0]))
+        total_files = len(by_file)
+        total_tasks = sum(len(v) for v in by_file.values())
+        print(f"[document] cycle {cycle}: {total_tasks} task(s) across "
+              f"{total_files} file(s).")
+
+        lock = Lock()
+        finished = [0]
+        failed = [0]
+        started = time.monotonic()
+
+        def fix_file(file, file_tasks):
+            file_tasks.sort(key=lambda t: -t["line"])
+            listing = "\n".join(
+                f"- line ~{t['line']}: {t['kind']} `{t['name']}`: {t['reason']}"
+                + (f"\n  current brief: \"{t['brief']}\"" if t.get("brief") else "")
+                for t in file_tasks)
+            seconds, code = run_agent(render("document", file=file, tasks=listing))
+            with lock:
+                finished[0] += 1
+                if code == 0:
+                    # Only a clean agent run counts as done; a failed one is
+                    # left off the checkpoint so it is retried.
+                    for t in file_tasks:
+                        state["documented"].append(
+                            [t["file"], t["name"], t["reason"]])
+                    save_state(state)
+                else:
+                    failed[0] += 1
+                # ETA from wall-clock throughput, not per-file time: with
+                # several agents in flight, files finish faster than any one
+                # takes, so elapsed/finished already folds in the parallelism.
+                elapsed = time.monotonic() - started
+                rate = elapsed / finished[0]
+                eta = rate * (total_files - finished[0])
+                note = " FAILED" if code != 0 else ""
+                print(f"[document] {finished[0]}/{total_files} files{note} "
+                      f"({len(file_tasks)} task(s) in {seconds:.0f}s, "
+                      f"{rate:.0f}s/file wall, ~{eta / 60:.0f}min left)")
+
+        if PARALLEL > 1:
+            with ThreadPoolExecutor(max_workers=PARALLEL) as pool:
+                futures = [pool.submit(fix_file, f, ts)
+                           for f, ts in ordered_files]
+                for future in as_completed(futures):
+                    future.result()
+        else:
+            for f, ts in ordered_files:
+                fix_file(f, ts)
+
+        if failed[0] == total_files:
+            agent_broken("document")
+            return False
+        if failed[0]:
+            print(f"[document] {failed[0]}/{total_files} file(s) had a "
+                  f"failing agent; they will be retried next cycle.")
+
+        # The checkpoint only protects a cycle against interruption. Once a
+        # cycle completes, the next dump is the ground truth: a task that
+        # still shows up was not really fixed and must be queued again.
+        state["documented"] = []
+        save_state(state)
+    print(f"[document] work-list still not empty after {CYCLES} cycles.",
+          file=sys.stderr)
+    return False
+
+
+def extract_json():
+    """Run the JSON generator once. Returns (returncode, corpus|None,
+    output, cmd); corpus is None when no reference.json was produced."""
+    with tempfile.TemporaryDirectory(prefix="fix-docs-") as out:
+        code, text, cmd = run_mrdocs([
+            "--generator=json", f"--output={out}",
+            "--warnings=false", "--log-level=warn"])
+        path = Path(out) / "reference.json"
+        corpus = json.loads(path.read_text(encoding="utf-8")) \
+            if path.exists() else None
+    return code, corpus, text, cmd
+
+
+def dump_work_list():
+    """Extract with the JSON generator and derive the work-list."""
+    code, corpus, text, _ = extract_json()
+    if corpus is None:
+        sys.exit(f"the json generator produced no output "
+                 f"(exit {code}):\n{text.strip()[-2000:]}")
+    return work_list_from(corpus)
+
+
+def work_list_from(corpus):
+    """Derive the work-list from a corpus, in index order."""
+    symbols = corpus.get("symbols", [])
+    by_id = {s["id"]: s for s in symbols if "id" in s}
+    tasks = [t for s in symbols for t in tasks_for(s, by_id)]
+    tasks.sort(key=index_rank)
+    return tasks
+
+
+def index_rank(task):
+    """Sort key placing a task where its symbol sits in the index: shallower
+    namespaces first (the global namespace, then one level, then two...),
+    alphabetical within a level."""
+    return (task["depth"], task["name"].lower())
+
+
+def tasks_for(sym, by_id):
+    """Every work-list entry a symbol needs (zero or more).
+
+    These mirror the offline-computable subset of the strict warnings, so
+    the warnings phase has almost nothing left to catch: undocumented
+    symbols (namespaces included), missing or anomalous briefs, function
+    parameters with no doc, and undocumented enum values. Only regular
+    (documented-surface) symbols are considered. The global namespace, which
+    has no name and no location, drops out on its own below.
+    """
+    if sym.get("extraction", "regular") != "regular":
+        return []
+    kind = sym.get("kind", "?")
+    name = qualified_name(sym, by_id)
+    tasks = classify(sym, by_id, kind, name)
+    # Every task from one symbol shares its index depth (the enum-constant's
+    # namespaces are the same as its enum's). Stamp it once for sorting.
+    depth = namespace_depth(sym, by_id)
+    for task in tasks:
+        task["depth"] = depth
+    return tasks
+
+
+def classify(sym, by_id, kind, name):
+    """The reasons a symbol needs work, as unranked tasks."""
+    # Enum values are separate symbols with no location of their own, so
+    # report them at the parent enum. Only when the enum itself is
+    # documented: a wholly-undocumented enum stays one task, and its values
+    # get written when the agent documents it.
+    if kind == "enum-constant":
+        parent = by_id.get(sym.get("parent"))
+        if sym.get("doc") or not (parent and parent.get("doc")):
+            return []
+        loc = symbol_loc(parent)
+        return [make_task(loc, name, kind, "undocumented enum value")] \
+            if loc else []
+
+    loc = symbol_loc(sym)
+    if not loc:
+        return []
+
+    if not sym.get("doc"):
+        # The whole symbol is undocumented; the agent writes its brief,
+        # params, and enum values in one comment, so no detail tasks here.
+        return [make_task(loc, name, kind, "undocumented")]
+
+    tasks = []
+    brief = brief_text(sym)
+    if not brief:
+        tasks.append(make_task(loc, name, kind, "no-brief"))
+    else:
+        anomaly = brief_anomaly(brief)
+        if anomaly:
+            tasks.append(make_task(loc, name, kind,
+                                   f"anomalous-brief: {anomaly}", brief))
+
+    # A documented function whose parameters are not fully documented: named
+    # ones with no @param, and unnamed ones (which must first be given a name
+    # in the signature before they can be documented at all).
+    if kind == "function":
+        missing = missing_param_docs(sym)
+        if missing:
+            tasks.append(make_task(loc, name, kind,
+                                   "missing param doc: " + ", ".join(missing)))
+        unnamed = sum(1 for p in sym.get("params", []) if not p.get("name"))
+        if unnamed:
+            tasks.append(make_task(loc, name, kind,
+                                   f"unnamed parameter(s): {unnamed}"))
+    return tasks
+
+
+def namespace_depth(sym, by_id):
+    """How many named namespaces enclose a symbol: 0 in the global namespace,
+    1 one level in, and so on. Macros and other global symbols are 0."""
+    depth = 0
+    cur = by_id.get(sym.get("parent"))
+    while cur is not None:
+        if cur.get("kind") == "namespace" and cur.get("name"):
+            depth += 1
+        cur = by_id.get(cur.get("parent"))
+    return depth
+
+
+def symbol_loc(sym):
+    """A symbol's definition location, or None when it has no usable one."""
+    loc = (sym.get("loc") or {}).get("defLoc") \
+        or ((sym.get("loc") or {}).get("loc") or [None])[0]
+    if loc and loc.get("sourcePath") and loc.get("lineNumber"):
+        return loc
+    return None
+
+
+def make_task(loc, name, kind, reason, brief=None):
+    task = {
+        "file": loc["sourcePath"],
+        "line": int(loc["lineNumber"]),
+        "name": name,
+        "kind": kind,
+        "reason": reason,
+    }
+    if brief:
+        task["brief"] = brief[:200] + ("..." if len(brief) > 200 else "")
+    return task
+
+
+def missing_param_docs(sym):
+    """Named parameters of a function that have no @param entry."""
+    documented = {p.get("name")
+                  for p in (sym.get("doc") or {}).get("params", [])}
+    return [p["name"] for p in sym.get("params", [])
+            if p.get("name") and p["name"] not in documented]
+
+
+def qualified_name(sym, by_id):
+    """A symbol's qualified name, built by walking parent ids."""
+    parts = []
+    cur = sym
+    while cur and cur.get("name"):
+        parts.append(cur["name"])
+        cur = by_id.get(cur.get("parent"))
+    return "::".join(reversed(parts))
+
+
+def brief_text(sym):
+    """A symbol's brief as trimmed plain text, or "" when it has none."""
+    brief = (sym.get("doc") or {}).get("brief")
+
+    def walk(node):
+        text = node.get("literal", "") if isinstance(node, dict) else ""
+        for child in (node.get("children") or []) if isinstance(node, dict) else []:
+            text += walk(child)
+        return text
+
+    return walk(brief).strip() if brief else ""
+
+
+def brief_anomaly(brief):
+    """Why a brief is anomalous, or None when it looks fine: text that was
+    never meant as a brief (a description paragraph, a banner) picked up as
+    one."""
+    if len(brief) < 4:
+        return "too short"
+    if len(brief) > 160:
+        return f"too long, reads like a description ({len(brief)} chars)"
+    run = re.search(r"([^\w\s])(\s*\1){3,}", brief)
+    if run:
+        return f"run of repeated '{run.group(1)}'"
+    visible = [c for c in brief if not c.isspace()]
+    special = sum(1 for c in visible if not c.isalnum())
+    if special > len(visible) / 2:
+        return "mostly punctuation"
+    return None
+
+
+# -------- phase 3: fix until mrdocs reports no warnings
+
+def phase_warnings():
+    previous = None
+    for round in range(1, MAX_ROUNDS + 1):
+        code, out, cmd = run_mrdocs(
+            ["--generator=noop", *STRICT, "--log-level=warn"])
+        blocks = diagnostics(out)
+        if code == 0 and not blocks and "Extracted 0 declarations" not in out:
+            print(f"[warnings] clean after {round - 1} round(s).")
+            return True
+        headers = tuple(b.splitlines()[0] for b in blocks)
+        if headers and headers == previous:
+            print("[warnings] the same locations came back unchanged; "
+                  "stopping so a human can look.", file=sys.stderr)
+            return False
+        previous = headers
+
+        batches = [blocks[i:i + BATCH] for i in range(0, len(blocks), BATCH)] \
+            or [[out.strip() or "(no output)"]]
+        print(f"[warnings] round {round}: {len(blocks)} location(s) in "
+              f"{len(batches)} batch(es).")
+        failures = 0
+        for i, batch in enumerate(batches, 1):
+            seconds, agent_code = run_agent(render(
+                "warnings",
+                command=shlex.join(cmd),
+                batch_index=i,
+                batch_count=len(batches),
+                report="\n\n".join(batch)))
+            note = " FAILED" if agent_code != 0 else ""
+            failures += agent_code != 0
+            print(f"[warnings] batch {i}/{len(batches)}{note} done in "
+                  f"{seconds:.0f}s.")
+        if failures == len(batches):
+            agent_broken("warnings")
+            return False
+    print("[warnings] out of rounds.", file=sys.stderr)
+    return False
+
+
+def diagnostics(report):
+    """Split the report into its location-grouped blocks."""
+    blocks, current = [], []
+    for line in report.splitlines():
+        if FOOTER.match(line):
+            continue
+        if LOCATION.match(line):
+            if current:
+                blocks.append("\n".join(current))
+            current = [line]
+        elif current:
+            current.append(line)
+    if current:
+        blocks.append("\n".join(current))
+    return [b for b in blocks if b.strip()]
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/fix-docs/prompts/compile.md
+++ b/tools/fix-docs/prompts/compile.md
@@ -1,0 +1,29 @@
+# Make the project compile under Mr.Docs
+
+Mr.Docs failed to extract this project because some translation units do not
+compile. Your job is to make extraction succeed.
+
+## How extraction was invoked
+
+```text
+{command}
+```
+
+## Rules
+
+- Fix the Mr.Docs configuration (`{config}`), the shim headers it references,
+  or both. Prefer, in order: adding an include directory that provides the
+  missing header, adding or extending a shim header, adding the missing
+  include prefix to `missing-include-prefixes`, and only as a last resort
+  excluding the file with `exclude-patterns`.
+  See: https://mrdocs.com/docs/mrdocs/migration-notes.html#shim-files
+- Don't change the library's own source to make it compile, except for files
+  that exist only to support the documentation build.
+- You can iterate quickly without a full run: compile one failing header
+  directly with clang and the include flags from the command above, or copy
+  the config and restrict `input:` to the failing directory.
+- When you are done, reply with a one-line summary of what you changed.
+
+## Compiler errors
+
+{errors}

--- a/tools/fix-docs/prompts/document.md
+++ b/tools/fix-docs/prompts/document.md
@@ -1,0 +1,39 @@
+# Documentation batch: one file
+
+Mr.Docs extracted this project and produced a work list of symbols whose
+documentation is missing or broken. This batch covers every problem in one
+file, listed below. Fix all of them in a single pass over the file. Don't run
+Mr.Docs. The list is already complete for this file.
+
+## File
+
+`{file}`
+
+## Rules
+
+- Write doc comments in the project's existing comment style. Look at a
+  well-documented symbol in the same file or a sibling file first and imitate
+  it: comment markers, tag vocabulary, indentation, line width.
+- A brief is one sentence, roughly 4 to 160 characters, that says what the
+  symbol is or does. Details, parameter lists, return values, and examples go
+  after the brief, not inside it.
+- "undocumented" on a function or enum means write the whole comment: brief,
+  every parameter, and every enum value. "missing param doc" and
+  "undocumented enum value" call out the specific gaps on a symbol that is
+  otherwise documented.
+- "anomalous-brief" means the text picked up as the brief was never meant as
+  one, or it's just a bad brief: a description paragraph, a banner, a stray
+  fragment. Write a real one-sentence brief. Keep the original text as the
+  description when it carries information, and delete it when it's decoration.
+- Line numbers below are hints from before any edits, so locate each symbol by
+  its name and signature. Working from the bottom of the file upward keeps
+  the remaining hints accurate.
+- Only edit documentation comments. The one exception: when a task says a
+  function has unnamed parameters, give each one a name in the declaration so
+  it can be documented, then document it. That is the only code edit allowed.
+- When you are done, reply with a one-line summary: how many symbols you
+  documented and how many briefs you rewrote.
+
+## Work-list for this file
+
+{tasks}

--- a/tools/fix-docs/prompts/warnings.md
+++ b/tools/fix-docs/prompts/warnings.md
@@ -1,0 +1,27 @@
+# Documentation repair batch: Mr.Docs warnings
+
+Mr.Docs ran a strict documentation check and produced the diagnostics below.
+Fix every problem in this batch so these diagnostics go away. Don't run
+Mr.Docs yourself. The driver re-runs it after all batches are done.
+
+## How the check was invoked
+
+```text
+{command}
+```
+
+## Rules
+
+- Each block starts with `path:line:col:` and lists numbered problems at that
+  location, usually with a source snippet.
+- Match the project's existing documentation style: comment markers, tag
+  vocabulary, indentation, line width.
+- Only edit documentation comments and, when a diagnostic points at the
+  Mr.Docs configuration, the config. Never change code.
+- This is batch {batch_index} of {batch_count} from one check run. Other
+  batches cover other locations, so stay inside the ones listed here.
+- When you are done, reply with a one-line summary of what you fixed.
+
+## Diagnostics
+
+{report}


### PR DESCRIPTION
Documenting a large project by hand is slow, and the existing example loop re-runs extraction on every pass to find the next thing to fix. This adds a user-facing tool that drives an AI agent to fill in a project's missing documentation. It extracts the project once with the JSON generator and fixes the documentation.

## Changes

The tool works in three phases: it first gets the project to extract, then documents every problem the checks can find offline, then clears whatever the strict check still reports. It visits files in index order and edits each file from the bottom up, so an interrupted run leaves the top of the index done and line numbers stay stable during a pass.

## Testing

The tool drives a live AI agent, so like the example loop, it has no automated test and does not run in CI.

## Documentation

The existing example page now includes a brief reference to the tool. No other docs are needed.
