### PR TITLE
ci: master releases

### DIFF
--- a/.github/workflows/ci-publish.yml
+++ b/.github/workflows/ci-publish.yml
@@ -52,6 +52,8 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: write
+      # `gh workflow run` in "Cut calendar release" below.
+      actions: write
     steps:
       # Aggregator: succeed only if every upstream job ended in success or
       # skipped. Failure or cancellation fails this job so the branch
@@ -245,6 +247,9 @@ jobs:
           # (see "Publish demos to dev-websites" above).
           time rsync "${rsyncopts[@]}" --exclude=demos/ $(pwd)/build/website/ "$website_dir"/
 
+      # Both SemVer tags (v0.8.0) and calendar release tags (2026.9.2,
+      # 2026.9.2+1) delimit the changelog, so each calendar release lists the
+      # commits since the previous one rather than since the last SemVer tag.
       - name: Create changelog
         if: inputs.should-publish
         uses: alandefreitas/cpp-actions/create-changelog@v1.9.5
@@ -252,16 +257,18 @@ jobs:
           output-path: CHANGELOG.md
           thank-non-regular: ${{ startsWith(github.ref, 'refs/tags/') }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          tag-pattern: '^(v\d+\.\d+\.\d+|20\d\d\.\d{1,2}\.\d{1,2}(\+\d+)?)$'
           limit: 150
           update-summary: true
 
-      # For non-tag publishes (develop-release and master-release rolling
-      # releases), strip the project version out of the package filenames
-      # and insert the branch name instead. Subsequent pushes overwrite the
-      # existing GitHub-release assets cleanly. Tag releases keep their
-      # versioned filenames.
-      - name: Rebrand branch packages
-        if: inputs.should-publish && !startsWith(github.ref, 'refs/tags/')
+      # CPack names packages after the project version (MrDocs-0.8.0-*).
+      # Only SemVer tag releases keep that name. Rolling branch releases
+      # (develop-release, master-release) get the branch name instead, so
+      # subsequent pushes overwrite the existing GitHub-release assets
+      # cleanly, and calendar releases get their release label
+      # (MrDocs-2026.9.2-*) so downloads say which release they are.
+      - name: Rebrand branch and calendar-release packages
+        if: inputs.should-publish && !startsWith(github.ref, 'refs/tags/v')
         run: |
           set -euxo pipefail
           cd packages
@@ -282,4 +289,54 @@ jobs:
           body_path: CHANGELOG.md
           prerelease: false
           draft: false
+          # Tag releases (SemVer or calendar) become the "Latest" release
+          # users land on; the rolling branch releases never do.
+          make_latest: ${{ startsWith(github.ref, 'refs/tags/') && 'true' || 'false' }}
           token: ${{ github.token }}
+
+      # Every push to master is a calendar release. The label is the UTC
+      # commit date of the master commit (YYYY.M.D, no zero padding so it is
+      # valid semver for the tools that parse it); a second release on the
+      # same day appends semver build metadata (+1, +2, ...). The project
+      # version in CMake is untouched: the release label lives in the tag,
+      # the release name, the package filenames, and `mrdocs --version`.
+      #
+      # A tag pushed with GITHUB_TOKEN does not start a workflow run on its
+      # own, so the tag build is started explicitly through workflow_dispatch
+      # (which that token may trigger). The dispatched run then takes the
+      # normal tag path in this job and creates the GitHub Release.
+      - name: Cut calendar release (master only)
+        if: inputs.should-publish && github.ref == 'refs/heads/master'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          release_re='^20[0-9]{2}\.[0-9]{1,2}\.[0-9]{1,2}(\+[0-9]+)?$'
+          if git tag --points-at HEAD | grep -Eq "$release_re"; then
+            echo "HEAD already carries a calendar release tag; nothing to cut."
+            exit 0
+          fi
+          label=$(date -u -d "@$(git log -1 --format=%ct HEAD)" '+%Y.%-m.%-d')
+          candidate="$label"
+          n=1
+          while git ls-remote --exit-code --tags origin "refs/tags/$candidate" >/dev/null 2>&1; do
+            candidate="$label+$n"
+            n=$((n + 1))
+          done
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git tag -a "$candidate" -m "MrDocs release $candidate"
+          git push origin "refs/tags/$candidate"
+          echo "Pushed calendar release tag $candidate"
+          # The tag can take a moment to become visible to the API.
+          for attempt in 1 2 3 4 5; do
+            if gh workflow run ci.yml --ref "$candidate"; then
+              echo "Started the release build for $candidate"
+              exit 0
+            fi
+            echo "gh workflow run failed (attempt $attempt); retrying..."
+            sleep 10
+          done
+          echo "::error::could not start the release build for $candidate"
+          exit 1

--- a/.github/workflows/ci-scope-detector.yml
+++ b/.github/workflows/ci-scope-detector.yml
@@ -98,6 +98,7 @@ jobs:
         id: classify
         env:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
+          GITHUB_REF_TYPE: ${{ github.ref_type }}
           BASE_REF: ${{ github.base_ref }}
           MERGE_GROUP_BASE_SHA: ${{ github.event.merge_group.base_sha }}
           PR_BODY: ${{ github.event.pull_request.body }}
@@ -106,9 +107,13 @@ jobs:
           set -euo pipefail
 
           # is-push is exposed as its own signal so consumers can react to
-          # push events without having to re-detect github.event_name.
+          # push events without having to re-detect github.event_name. A
+          # workflow_dispatch on a tag is how ci-publish starts the build of a
+          # calendar release tag it just cut, so it counts as a push too.
           is_push='false'
           if [[ "$GITHUB_EVENT_NAME" == 'push' ]]; then
+            is_push='true'
+          elif [[ "$GITHUB_EVENT_NAME" == 'workflow_dispatch' && "$GITHUB_REF_TYPE" == 'tag' ]]; then
             is_push='true'
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,15 @@ on:
       - master
       - '**'
     tags:
+      # SemVer releases (v0.8.0) and calendar releases (2026.9.2, 2026.9.2+1).
       - "v*.*.*"
+      - "20[0-9][0-9].*.*"
+
+  # Publish dispatches ci.yml on a freshly cut calendar release tag: a tag
+  # pushed with GITHUB_TOKEN does not start a run on its own, but
+  # workflow_dispatch is exempt from that rule. The dispatched run behaves
+  # exactly like a tag push (scope-detector reports is-push for it).
+  workflow_dispatch:
 
   # pull_request runs the matrix/build on the PR head with the fork-scoped token
   # (no comment perms on base repo).
@@ -132,6 +140,8 @@ jobs:
     if: always()
     permissions:
       contents: write
+      # ci-publish dispatches the release build of a freshly cut master tag.
+      actions: write
     uses: ./.github/workflows/ci-publish.yml
     with:
       submatrix: ${{ toJSON(fromJSON(needs.cpp-matrix.outputs.submatrices).releases) }}

--- a/docs/antora-playbook.yml
+++ b/docs/antora-playbook.yml
@@ -35,7 +35,10 @@ antora:
     - require: '@alandefreitas/antora-playbook-macros-extension'
       macros:
         branchesarray: [ develop, master ]
-        tagsarray: [ v* ]
+        # Every v* release tag except the v0.0.x patches (stepping stones
+        # to v0.8.0), plus every calendar release tag (2026.9.2). Antora's
+        # ref globs support *, braces and ! exclusions, but not [] classes.
+        tagsarray: [ v*, '!v0.0.*', '2*.*.*' ]
     - require: '@sntke/antora-mermaid-extension' # <1>
       mermaid_library_url: https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs # <2>
       script_stem: header-scripts

--- a/docs/extensions/mrdocs-releases.js
+++ b/docs/extensions/mrdocs-releases.js
@@ -155,7 +155,7 @@ module.exports = function (registry) {
             const releasesResponse =
                 readFromCacheFile ?
                     fs.readFileSync(cachePath, 'utf-8') :
-                    fetchWithRetry('https://api.github.com/repos/cppalliance/mrdocs/releases', apiHeaders)
+                    fetchWithRetry('https://api.github.com/repos/cppalliance/mrdocs/releases?per_page=100', apiHeaders)
             if (!readFromCacheFile) {
                 fs.writeFileSync(cachePath, releasesResponse);
             }

--- a/include/mrdocs/Version.hpp.in
+++ b/include/mrdocs/Version.hpp.in
@@ -46,6 +46,35 @@ inline constexpr std::size_t      project_version_patch       = @PROJECT_VERSION
 */
 inline constexpr std::string_view project_version_build       = "@PROJECT_VERSION_BUILD@";
 
+/** Calendar release label in YYYY.M.D format.
+
+    On a commit carrying a calendar release tag this is that tag
+    (for example "2026.9.2", or "2026.9.2+1" for a second release
+    on the same day). Otherwise it is the UTC commit date of the
+    build. Empty if the git information was unavailable.
+*/
+inline constexpr std::string_view project_release             = "@PROJECT_RELEASE@";
+
+/** Calendar release label with build metadata.
+
+    Equal to project_release on a tagged release. Otherwise appends
+    the git short SHA, and ".modified" if the working tree was
+    modified.
+*/
+inline constexpr std::string_view project_release_with_build  = "@PROJECT_RELEASE_WITH_BUILD@";
+
+/** Year of the calendar release (0 if unavailable).
+*/
+inline constexpr std::size_t      project_release_year        = @PROJECT_RELEASE_YEAR@;
+
+/** Month of the calendar release, 1 to 12 (0 if unavailable).
+*/
+inline constexpr std::size_t      project_release_month       = @PROJECT_RELEASE_MONTH@;
+
+/** Day of the calendar release, 1 to 31 (0 if unavailable).
+*/
+inline constexpr std::size_t      project_release_day         = @PROJECT_RELEASE_DAY@;
+
 /** Canonical project name.
 */
 inline constexpr std::string_view project_name                = "@PROJECT_NAME@";

--- a/mrdocs-config.cmake.in
+++ b/mrdocs-config.cmake.in
@@ -18,6 +18,14 @@ set(MRDOCS_BUILT_REEXPORT_DEPENDENCIES "@MRDOCS_DO_REEXPORT_DEPENDENCIES@")
 set(MRDOCS_BUILT_CXX_COMPILER_ID "@CMAKE_CXX_COMPILER_ID@")
 set(MRDOCS_BUILT_CXX_COMPILER_VERSION "@CMAKE_CXX_COMPILER_VERSION@")
 
+# Calendar release this installation was built from (YYYY.M.D), decomposed
+# like mrdocs_VERSION_MAJOR/MINOR/PATCH. Empty/0 when git was unavailable.
+set(MRDOCS_RELEASE            "@MRDOCS_RELEASE@")
+set(MRDOCS_RELEASE_WITH_BUILD "@MRDOCS_RELEASE_WITH_BUILD@")
+set(MRDOCS_RELEASE_YEAR       "@MRDOCS_RELEASE_YEAR@")
+set(MRDOCS_RELEASE_MONTH      "@MRDOCS_RELEASE_MONTH@")
+set(MRDOCS_RELEASE_DAY        "@MRDOCS_RELEASE_DAY@")
+
 # Installation paths, relocated relative to this file by @PACKAGE_INIT@.
 set_and_check(MRDOCS_INCLUDE_DIR  "@PACKAGE_INCLUDE_INSTALL_DIR@")   # e.g. "include"
 set_and_check(MRDOCS_LIB_DIR      "@PACKAGE_LIB_INSTALL_DIR@")       # e.g. "lib" or "lib64"

--- a/src/mrdocs/Support/Report.cpp
+++ b/src/mrdocs/Support/Report.cpp
@@ -166,6 +166,10 @@ call_impl(
             os << "An issue occurred during execution.\n";
             os << "If you believe this is a bug, please report it at https://github.com/cppalliance/mrdocs/issues\n"
                   "with the following details:\n";
+            os << std::format("    MrDocs Release: {}\n",
+                              project_release_with_build.empty()
+                                  ? std::string_view("unknown")
+                                  : project_release_with_build);
             os << std::format("    MrDocs Version: {} (Build: {})\n",
                               project_version, project_version_build);
             if (e)

--- a/tools/fix-docs/fix-docs.py
+++ b/tools/fix-docs/fix-docs.py
@@ -109,7 +109,7 @@ STRICT = [
 ANSI = re.compile(r"\x1b\[[0-9;]*m")
 LOCATION = re.compile(r"^\S.*:\d+:\d+:\s*$")
 FOOTER = re.compile(
-    r"^(An issue occurred|If you believe|\s*MrDocs Version|\s*Error Location|"
+    r"^(An issue occurred|If you believe|\s*MrDocs Release|\s*MrDocs Version|\s*Error Location|"
     r"\s*Reported From|with the following details|error limit reached)")
 
 

--- a/tools/mrdocs/src/Main.cpp
+++ b/tools/mrdocs/src/Main.cpp
@@ -115,7 +115,13 @@ printHelp(llvm::raw_ostream& os)
 static void
 printVersion(llvm::raw_ostream& os, std::string const& execPath)
 {
-    os << project_name << " version " << project_version_with_build << "\n";
+    os << project_name << "\n";
+    os << "Release: "
+       << (project_release_with_build.empty()
+               ? std::string_view("unknown")
+               : project_release_with_build)
+       << "\n";
+    os << "Version: " << project_version_with_build << "\n";
     os << "Built with LLVM " << LLVM_VERSION_STRING << "\n";
     os << "Build SHA: " << project_version_build << "\n";
     os << "Target: " << llvm::sys::getDefaultTargetTriple() << "\n";

--- a/utils/cmake/install.cmake
+++ b/utils/cmake/install.cmake
@@ -45,6 +45,25 @@ function(mrdocs_install)
             DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/mrdocs)
 
     # mrdocs-config.cmake
+    #
+    # The calendar release label comes from git (the release tag on HEAD, or
+    # the UTC commit date), read at configure time by the same script that
+    # stamps Version.hpp so both agree. PYTHON_EXECUTABLE and GIT_EXECUTABLE
+    # are cache entries set by utils/codegen.
+    execute_process(
+            COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/utils/codegen/generate-version-header.py
+                    --print-release
+                    --source-dir ${PROJECT_SOURCE_DIR}
+                    --git "${GIT_EXECUTABLE}"
+            OUTPUT_VARIABLE MRDOCS_RELEASE_FIELDS
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+            COMMAND_ERROR_IS_FATAL ANY)
+    list(GET MRDOCS_RELEASE_FIELDS 0 MRDOCS_RELEASE)
+    list(GET MRDOCS_RELEASE_FIELDS 1 MRDOCS_RELEASE_WITH_BUILD)
+    list(GET MRDOCS_RELEASE_FIELDS 2 MRDOCS_RELEASE_YEAR)
+    list(GET MRDOCS_RELEASE_FIELDS 3 MRDOCS_RELEASE_MONTH)
+    list(GET MRDOCS_RELEASE_FIELDS 4 MRDOCS_RELEASE_DAY)
+
     set(INCLUDE_INSTALL_DIR ${CMAKE_INSTALL_INCLUDEDIR})
     set(LIB_INSTALL_DIR ${CMAKE_INSTALL_LIBDIR})
     set(BIN_INSTALL_DIR ${CMAKE_INSTALL_BINDIR})

--- a/utils/codegen/generate-version-header.py
+++ b/utils/codegen/generate-version-header.py
@@ -12,10 +12,30 @@
 # friends, stamping the git build metadata. Like the other codegen scripts, it is
 # meant to run at build time so the SHA reflects the commit being built; it only
 # rewrites the output when the content changes, so it never forces a rebuild.
+#
+# Two labels are stamped:
+#
+# - The project version (MAJOR.MINOR.PATCH from CMake), with the short SHA
+#   appended when HEAD is not exactly on a tag.
+# - The release label (YYYY.M.D), which is the calendar release this build
+#   belongs to. On a commit carrying a calendar release tag it is that tag;
+#   otherwise it is the UTC commit date of HEAD with the short SHA appended.
+#   Deriving it from git rather than the wall clock keeps builds reproducible.
+#   The year, month, and day are also exposed separately, mirroring the
+#   MAJOR/MINOR/PATCH decomposition of the version.
+#
+# `--print-release` skips the header and prints the release fields instead,
+# for CMake to embed them in the installed mrdocs-config.cmake.
 
 import argparse
 import os
+import re
 import subprocess
+from datetime import datetime, timezone
+
+# Calendar release tags: YYYY.M.D with optional semver build metadata for a
+# second release on the same day (2026.9.2, 2026.9.2+1, ...).
+RELEASE_TAG_RE = re.compile(r"^(20\d{2})\.(\d{1,2})\.(\d{1,2})(?:\+(\d+))?$")
 
 
 def git(git_exe, args, source_dir):
@@ -24,39 +44,82 @@ def git(git_exe, args, source_dir):
         capture_output=True, text=True)
 
 
-def version_with_build(git_exe, version, source_dir):
-    """Return (version_with_build, full_sha) from the git state.
+def release_tag_key(tag):
+    m = RELEASE_TAG_RE.match(tag)
+    return tuple(int(g or 0) for g in m.groups())
+
+
+def git_state(git_exe, source_dir):
+    """Return (full_sha, short_sha, on_tag, release_tag, commit_utc, dirty).
 
     Git is optional here: CMake already found it (or decided it was not required)
-    before this runs, so on any git failure we just fall back to the plain version.
+    before this runs, so on any git failure every field is empty/False and the
+    caller falls back to the plain version.
     """
+    empty = ("", "", False, "", None, False)
     try:
         head = git(git_exe, ["rev-parse", "HEAD"], source_dir)
     except OSError:
         # git executable not found: fall back to the plain version.
-        return version, ""
+        return empty
     if head.returncode != 0:
-        return version, ""
+        return empty
 
     full_sha = head.stdout.strip()
     short_sha = full_sha[:12]
 
     # Exactly on a tag: canonical release, no build metadata.
     on_tag = git(git_exe, ["describe", "--tags", "--exact-match", "HEAD"], source_dir).returncode == 0
-    if on_tag:
-        return version, full_sha
 
-    # Off a tag: append the short SHA, plus .modified if the tree is dirty.
+    # Calendar release tags pointing at HEAD (there is normally one; if a
+    # commit got re-released the same day, prefer the newest label).
+    points_at = git(git_exe, ["tag", "--points-at", "HEAD"], source_dir)
+    release_tags = [t for t in points_at.stdout.split() if RELEASE_TAG_RE.match(t)]
+    release_tag = max(release_tags, key=release_tag_key) if release_tags else ""
+
+    commit_utc = None
+    committed = git(git_exe, ["log", "-1", "--format=%ct", "HEAD"], source_dir)
+    if committed.returncode == 0 and committed.stdout.strip().isdigit():
+        commit_utc = datetime.fromtimestamp(int(committed.stdout.strip()), tz=timezone.utc)
+
     dirty = git(git_exe, ["diff", "--quiet", "--ignore-submodules"], source_dir).returncode == 1
+    return full_sha, short_sha, on_tag, release_tag, commit_utc, dirty
+
+
+def version_with_build(version, state):
+    """Return the project version with build metadata."""
+    full_sha, short_sha, on_tag, _, _, dirty = state
+    if not full_sha or on_tag:
+        return version
     suffix = ".modified" if dirty else ""
-    return f"{version}+{short_sha}{suffix}", full_sha
+    return f"{version}+{short_sha}{suffix}"
+
+
+def release_labels(state):
+    """Return (release, release_with_build, (year, month, day)).
+
+    The labels are empty and the components are zero when git information
+    was unavailable.
+    """
+    _, short_sha, _, release_tag, commit_utc, dirty = state
+    if release_tag:
+        year, month, day, _ = release_tag_key(release_tag)
+        return release_tag, release_tag, (year, month, day)
+    if commit_utc is None:
+        return "", "", (0, 0, 0)
+    release = f"{commit_utc.year}.{commit_utc.month}.{commit_utc.day}"
+    suffix = ".modified" if dirty else ""
+    return release, f"{release}+{short_sha}{suffix}", (commit_utc.year, commit_utc.month, commit_utc.day)
 
 
 def main():
     parser = argparse.ArgumentParser(description="Generate Version.hpp from Version.hpp.in")
-    parser.add_argument("template", help="path to Version.hpp.in")
-    parser.add_argument("output", help="path to the Version.hpp to generate")
-    parser.add_argument("--version", required=True, help="project version (MAJOR.MINOR.PATCH)")
+    parser.add_argument("template", nargs="?", help="path to Version.hpp.in")
+    parser.add_argument("output", nargs="?", help="path to the Version.hpp to generate")
+    parser.add_argument("--version", help="project version (MAJOR.MINOR.PATCH)")
+    parser.add_argument("--print-release", action="store_true",
+                        help="print 'release;release_with_build;year;month;day' and exit "
+                             "(CMake uses this at configure time for the installed package config)")
     parser.add_argument("--name", default="", help="project name")
     parser.add_argument("--description", default="", help="project description")
     parser.add_argument("--source-dir", default=".", help="repository root, used for the git queries")
@@ -65,7 +128,16 @@ def main():
     args = parser.parse_args()
 
     git_exe = args.git or "git"
-    build_version, build_sha = version_with_build(git_exe, args.version, args.source_dir)
+    state = git_state(git_exe, args.source_dir)
+    release, release_with_build, (year, month, day) = release_labels(state)
+    if args.print_release:
+        print(f"{release};{release_with_build};{year};{month};{day}")
+        return
+    if not (args.template and args.output and args.version):
+        parser.error("template, output, and --version are required unless --print-release is given")
+
+    build_version = version_with_build(args.version, state)
+    build_sha = state[0]
     # Split MAJOR.MINOR.PATCH, defaulting any missing component to 0.
     parts = (args.version.split(".") + ["0", "0", "0"])[:3]
     substitutions = {
@@ -77,6 +149,11 @@ def main():
         "PROJECT_VERSION_PATCH": parts[2],
         "PROJECT_VERSION_WITH_BUILD": build_version,
         "PROJECT_VERSION_BUILD": build_sha,
+        "PROJECT_RELEASE": release,
+        "PROJECT_RELEASE_WITH_BUILD": release_with_build,
+        "PROJECT_RELEASE_YEAR": str(year),
+        "PROJECT_RELEASE_MONTH": str(month),
+        "PROJECT_RELEASE_DAY": str(day),
     }
 
     content = ''
@@ -92,7 +169,8 @@ def main():
         with open(args.output, "r") as f:
             previous = f.read()
     if content != previous:
-        os.makedirs(os.path.dirname(args.output), exist_ok=True)
+        if os.path.dirname(args.output):
+            os.makedirs(os.path.dirname(args.output), exist_ok=True)
         with open(args.output, "w") as f:
             f.write(content)
 


### PR DESCRIPTION
Pushes to master now get their own GitHub Releases, so there is always a recent build to download, and each one keeps its name tag. A release/snapshot filename is named after the day it was cut: 2026.9.2, or 2026.9.2+1 for a second one on the same day.

## Changes

The publish job tags the master commit with its date and starts the tag build. That build uploads packages named after the tag, adds a docs version, and publishes the demos. The tool prints the release name first when asked for its version, and the installed CMake package carries the name and its year, month, and day.

## Testing

The full CI matrix, the three release package jobs, and the documentation builds passed on the fork (run 33696541391). The final tags are only created on a push to master, so that part remains untested until the first one.

## Documentation

The install page explains the release names and shows the version output.
