### PR TITLE
docs: antora-cpp-reference-extension 0.1.2

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -8,7 +8,7 @@
         "@alandefreitas/antora-playbook-macros-extension": "^0.0.1",
         "@antora/lunr-extension": "^1.0.0-alpha.12",
         "@asciidoctor/tabs": "^1.0.0-beta.6",
-        "@cppalliance/antora-cpp-reference-extension": "^0.1.1",
+        "@cppalliance/antora-cpp-reference-extension": "^0.1.2",
         "@cppalliance/antora-cpp-tagfiles-extension": "^0.1.1",
         "asciidoctor": "^3.0.4",
         "sync-request": "^6.1.0"
@@ -503,9 +503,9 @@
       }
     },
     "node_modules/@cppalliance/antora-cpp-reference-extension": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@cppalliance/antora-cpp-reference-extension/-/antora-cpp-reference-extension-0.1.1.tgz",
-      "integrity": "sha512-otGW/pJNtYyji62ELGkyEc6PseHxz882HhQGB1YUxPehg+2CjzM/hqQ7aJFXtaNAedrXK0/upQ+KCCs2WPWFqg==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@cppalliance/antora-cpp-reference-extension/-/antora-cpp-reference-extension-0.1.2.tgz",
+      "integrity": "sha512-IR/s81iAMSgKfE4E2uFxOQcTQl8JL+s+75nryzWxay5bgCFdzobo1Tv5RSihKa39ZRyRlQMpO4D07QMU+5kJRQ==",
       "license": "BSL-1.0",
       "dependencies": {
         "@antora/expand-path-helper": "^3.0.0",

--- a/docs/package.json
+++ b/docs/package.json
@@ -8,7 +8,7 @@
     "@alandefreitas/antora-playbook-macros-extension": "^0.0.1",
     "@antora/lunr-extension": "^1.0.0-alpha.12",
     "@asciidoctor/tabs": "^1.0.0-beta.6",
-    "@cppalliance/antora-cpp-reference-extension": "^0.1.1",
+    "@cppalliance/antora-cpp-reference-extension": "^0.1.2",
     "@cppalliance/antora-cpp-tagfiles-extension": "^0.1.1",
     "asciidoctor": "^3.0.4",
     "sync-request": "^6.1.0"


### PR DESCRIPTION
Updates the Antora reference extension to 0.1.2. The docs build uses one checkout folder for every version it builds, and the old extension could not replace a symlink whose target had changed between versions. That broke the publish job on both develop and master once master caught up with develop.

## Changes

The docs dependency files move the extension from 0.1.1 to 0.1.2.

## Testing

The extension carries its own unit test for the fix. The proof here is the publish job going green on develop and master after the merge.

## Documentation

No docs changes needed.